### PR TITLE
Fix start.sh script for zip packaging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.0.1 (10/02/2018)
 - [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script
+- Dependency JARs were accidentally being included twice in release packages.
 
 ## 2.0.0 (09/24/2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.1 (UNRELEASED)
+- [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script
+
 ## 2.0.0 (09/24/2018)
 
 - Added new Stream consumer management page at /configuration/stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.1 (UNRELEASED)
+## 2.0.1 (10/02/2018)
 - [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script
 
 ## 2.0.0 (09/24/2018)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM openjdk:8-jre-alpine
 MAINTAINER SourceLab.org <stephen.powis@gmail.com>
 
 ## Define what version of Kafka Webview to build the image using.
-ENV WEBVIEW_VER="2.0.0" \
-    WEBVIEW_SHA1="f94015afdb0043a350a590b163f1fa79b5026aad" \
+ENV WEBVIEW_VER="2.0.1" \
+    WEBVIEW_SHA1="TBD" \
     WEBVIEW_HOME="/app"
 
 # Create app and data directories

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "${WEBVIEW_SHA1}  /tmp/kafka-webview-ui-bin.zip" | sha1sum -c - && \
     unzip -d ${WEBVIEW_HOME} /tmp/kafka-webview-ui-bin.zip && \
     mv ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/* ${WEBVIEW_HOME} && \
     rm -rf ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/ && \
-    rm -f ${WEBVIEW_HOME}/src && \
+    rm -rf ${WEBVIEW_HOME}/src && \
     rm -f /tmp/kafka-webview-ui-bin.zip
 
 # Create volume to persist data

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN echo "${WEBVIEW_SHA1}  /tmp/kafka-webview-ui-bin.zip" | sha1sum -c - && \
     unzip -d ${WEBVIEW_HOME} /tmp/kafka-webview-ui-bin.zip && \
     mv ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/* ${WEBVIEW_HOME} && \
     rm -rf ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/ && \
-    rm -f ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}-sources.jar && \
-    rm -f ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}-javadoc.jar && \
+    rm -f ${WEBVIEW_HOME}/src && \
     rm -f /tmp/kafka-webview-ui-bin.zip
 
 # Create volume to persist data

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/src/assembly/assembly.xml
+++ b/kafka-webview-ui/src/assembly/assembly.xml
@@ -14,6 +14,7 @@
     </dependencySets>
 
     <fileSets>
+        <!-- Include startup scripts -->
         <fileSet>
             <directory>${basedir}/src/assembly/distribution/</directory>
             <outputDirectory></outputDirectory>
@@ -21,15 +22,26 @@
                 <include>*</include>
             </includes>
         </fileSet>
-        <!--
-            Adds the jar file of our example application to the root directory
-            of the created zip package.
-        -->
+        <!-- Put the main JAR at the top level -->
         <fileSet>
             <directory>${project.build.directory}</directory>
             <outputDirectory></outputDirectory>
             <includes>
                 <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>kafka-webview-ui-*-sources.jar</exclude>
+                <exclude>kafka-webview-ui-*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+
+        <!-- Put doc and source JARs under src/ -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>src/</outputDirectory>
+            <includes>
+                <include>kafka-webview-ui-*-sources.jar</include>
+                <include>kafka-webview-ui-*-javadoc.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/kafka-webview-ui/src/assembly/assembly.xml
+++ b/kafka-webview-ui/src/assembly/assembly.xml
@@ -3,7 +3,7 @@
     <formats>
         <format>zip</format>
     </formats>
-    
+
     <fileSets>
         <!-- Include startup scripts -->
         <fileSet>

--- a/kafka-webview-ui/src/assembly/assembly.xml
+++ b/kafka-webview-ui/src/assembly/assembly.xml
@@ -3,16 +3,7 @@
     <formats>
         <format>zip</format>
     </formats>
-
-    <!-- Adds the dependencies of our application to the lib directory -->
-    <dependencySets>
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>lib</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
-    </dependencySets>
-
+    
     <fileSets>
         <!-- Include startup scripts -->
         <fileSet>

--- a/kafka-webview-ui/src/assembly/assembly.xml
+++ b/kafka-webview-ui/src/assembly/assembly.xml
@@ -16,18 +16,30 @@
     <fileSets>
         <!-- Include startup scripts -->
         <fileSet>
-            <directory>${basedir}/src/assembly/distribution/</directory>
+            <directory>${project.basedir}/src/assembly/distribution/</directory>
             <outputDirectory></outputDirectory>
             <includes>
                 <include>*</include>
             </includes>
         </fileSet>
+
+        <!-- Include Changelog, Readme, and License from top level project directory -->
+        <fileSet>
+            <directory>${project.basedir}/../</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>CHANGELOG.md</include>
+                <include>README.md</include>
+                <include>LICENSE.txt</include>
+            </includes>
+        </fileSet>
+
         <!-- Put the main JAR at the top level -->
         <fileSet>
             <directory>${project.build.directory}</directory>
             <outputDirectory></outputDirectory>
             <includes>
-                <include>*.jar</include>
+                <include>kafka-webview-ui-${project.version}.jar</include>
             </includes>
             <excludes>
                 <exclude>kafka-webview-ui-*-sources.jar</exclude>
@@ -40,8 +52,8 @@
             <directory>${project.build.directory}</directory>
             <outputDirectory>src/</outputDirectory>
             <includes>
-                <include>kafka-webview-ui-*-sources.jar</include>
-                <include>kafka-webview-ui-*-javadoc.jar</include>
+                <include>kafka-webview-ui-${project.version}-sources.jar</include>
+                <include>kafka-webview-ui-${project.version}-javadoc.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Define submodules -->
     <modules>


### PR DESCRIPTION
- fix for #100 
- include README, CHANGELOG, and LICENSE in packaged zip.
- stop including dependencies in packaged zip twice.