### PR TITLE
Add ability to view consumer states stored within a Kafka Cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.1 (10/02/2018)
+- [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script
+- Dependency JARs were accidentally being included twice in release packages.
+
 ## 2.0.0 (09/24/2018)
 
 - Added new Stream consumer management page at /configuration/stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.2 (UNRELEAED)
+- Updated to Kafka Client library version 2.0.0.
+- Topics shown on brokers now includes "internal" topics.
+
 ## 2.0.1 (10/02/2018)
 - [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script
 - Dependency JARs were accidentally being included twice in release packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.2 (UNRELEAED)
+## 2.1.0 (UNRELEASED)
 #### New Features
-- More explicitly expose user login session timeout configuration value.
+- Consumer details can now be viewed on Clusters.
+- Explicitly expose user login session timeout configuration value in documentation.
+
+#### Bug fixes
 - Topics shown on brokers now include "internal" topics.
+- Generated consumer client.id shortened.
 
 #### Internal Dependency Updates
 - Upgrade from Spring Boot 2.0.5 to 2.0.7
@@ -14,7 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - sockjs-client from 1.1.4 to 1.3.0
   - browser-sync from 2.16.0 to 2.26.3
   - gulp-sass from 3.1.0 to 3.2.1
->>>>>>> d58ad8cdea2d36b208ade69dd6cc52af312e17cb
 
 ## 2.0.1 (10/02/2018)
 - [Issue#100](https://github.com/SourceLabOrg/kafka-webview/issues/100) Fix start.sh script

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM openjdk:8-jre-alpine
 MAINTAINER SourceLab.org <stephen.powis@gmail.com>
 
 ## Define what version of Kafka Webview to build the image using.
-ENV WEBVIEW_VER="2.0.0" \
-    WEBVIEW_SHA1="f94015afdb0043a350a590b163f1fa79b5026aad" \
+ENV WEBVIEW_VER="2.0.1" \
+    WEBVIEW_SHA1="TBD" \
     WEBVIEW_HOME="/app"
 
 # Create app and data directories
@@ -26,8 +26,7 @@ RUN echo "${WEBVIEW_SHA1}  /tmp/kafka-webview-ui-bin.zip" | sha1sum -c - && \
     unzip -d ${WEBVIEW_HOME} /tmp/kafka-webview-ui-bin.zip && \
     mv ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/* ${WEBVIEW_HOME} && \
     rm -rf ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}/ && \
-    rm -f ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}-sources.jar && \
-    rm -f ${WEBVIEW_HOME}/kafka-webview-ui-${WEBVIEW_VER}-javadoc.jar && \
+    rm -rf ${WEBVIEW_HOME}/src && \
     rm -f /tmp/kafka-webview-ui-bin.zip
 
 # Create volume to persist data

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.1</version>
+        <version>2.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.1</version>
+        <version>2.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -32,7 +32,7 @@
         <java.version>1.8</java.version>
         <bootstrap.version>4.0.0-beta</bootstrap.version>
         <thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
-        <kafka.version>1.1.1</kafka.version>
+        <kafka.version>2.0.0</kafka.version>
     </properties>
 
     <dependencies>

--- a/kafka-webview-ui/src/assembly/assembly.xml
+++ b/kafka-webview-ui/src/assembly/assembly.xml
@@ -4,32 +4,47 @@
         <format>zip</format>
     </formats>
 
-    <!-- Adds the dependencies of our application to the lib directory -->
-    <dependencySets>
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>lib</outputDirectory>
-            <unpack>false</unpack>
-        </dependencySet>
-    </dependencySets>
-
     <fileSets>
+        <!-- Include startup scripts -->
         <fileSet>
-            <directory>${basedir}/src/assembly/distribution/</directory>
+            <directory>${project.basedir}/src/assembly/distribution/</directory>
             <outputDirectory></outputDirectory>
             <includes>
                 <include>*</include>
             </includes>
         </fileSet>
-        <!--
-            Adds the jar file of our example application to the root directory
-            of the created zip package.
-        -->
+
+        <!-- Include Changelog, Readme, and License from top level project directory -->
+        <fileSet>
+            <directory>${project.basedir}/../</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>CHANGELOG.md</include>
+                <include>README.md</include>
+                <include>LICENSE.txt</include>
+            </includes>
+        </fileSet>
+
+        <!-- Put the main JAR at the top level -->
         <fileSet>
             <directory>${project.build.directory}</directory>
             <outputDirectory></outputDirectory>
             <includes>
-                <include>*.jar</include>
+                <include>kafka-webview-ui-${project.version}.jar</include>
+            </includes>
+            <excludes>
+                <exclude>kafka-webview-ui-*-sources.jar</exclude>
+                <exclude>kafka-webview-ui-*-javadoc.jar</exclude>
+            </excludes>
+        </fileSet>
+
+        <!-- Put doc and source JARs under src/ -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>src/</outputDirectory>
+            <includes>
+                <include>kafka-webview-ui-${project.version}-sources.jar</include>
+                <include>kafka-webview-ui-${project.version}-javadoc.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -264,6 +264,16 @@ var ApiClient = {
             .getJSON('/api/cluster/' + clusterId + '/consumersAndDetails', '', callback)
             .fail(ApiClient.defaultErrorHandler);
     },
+    getConsumerDetails: function(clusterId, consumerGroupId, callback) {
+        jQuery
+            .getJSON('/api/cluster/' + clusterId + '/consumer/' + consumerGroupId + '/details', '', callback)
+            .fail(ApiClient.defaultErrorHandler);
+    },
+    getConsumerOffsets: function(clusterId, consumerGroupId, callback) {
+        jQuery
+            .getJSON('/api/cluster/' + clusterId + '/consumer/' + consumerGroupId + '/offsets', '', callback)
+            .fail(ApiClient.defaultErrorHandler);
+    },
     removeConsumer: function(clusterId, consumerId, callback) {
         var payload = JSON.stringify({
             clusterId: clusterId,

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -259,6 +259,24 @@ var ApiClient = {
             .getJSON('/api/cluster/' + clusterId + '/consumers', '', callback)
             .fail(ApiClient.defaultErrorHandler);
     },
+    removeConsumer: function(clusterId, consumerId, callback) {
+        var payload = JSON.stringify({
+            clusterId: clusterId,
+            consumerId: consumerId
+        });
+        jQuery.ajax({
+            type: 'POST',
+            url: '/api/cluster/' + clusterId + '/consumer/remove',
+            data: payload,
+            dataType: 'json',
+            headers: ApiClient.getCsrfHeader(),
+            success: callback,
+            error: ApiClient.defaultErrorHandler,
+            beforeSend: function(xhr) {
+                xhr.setRequestHeader('Content-type', 'application/json; charset=utf-8');
+            }
+        });
+    },
     createTopic: function(clusterId, name, partitions, replicas, callback) {
         var payload = JSON.stringify({
             name: name,

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -274,6 +274,11 @@ var ApiClient = {
             .getJSON('/api/cluster/' + clusterId + '/consumer/' + consumerGroupId + '/offsets', '', callback)
             .fail(ApiClient.defaultErrorHandler);
     },
+    getConsumerOffsetsWithTailPositions: function(clusterId, consumerGroupId, callback) {
+        jQuery
+            .getJSON('/api/cluster/' + clusterId + '/consumer/' + consumerGroupId + '/offsetsAndTailPositions', '', callback)
+            .fail(ApiClient.defaultErrorHandler);
+    },
     removeConsumer: function(clusterId, consumerId, callback) {
         var payload = JSON.stringify({
             clusterId: clusterId,

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -259,6 +259,11 @@ var ApiClient = {
             .getJSON('/api/cluster/' + clusterId + '/consumers', '', callback)
             .fail(ApiClient.defaultErrorHandler);
     },
+    getAllConsumersWithDetails: function(clusterId, callback) {
+        jQuery
+            .getJSON('/api/cluster/' + clusterId + '/consumersAndDetails', '', callback)
+            .fail(ApiClient.defaultErrorHandler);
+    },
     removeConsumer: function(clusterId, consumerId, callback) {
         var payload = JSON.stringify({
             clusterId: clusterId,

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -254,6 +254,11 @@ var ApiClient = {
             .getJSON('/api/cluster/' + clusterId + '/broker/' + brokerId + '/config', '', callback)
             .fail(ApiClient.defaultErrorHandler);
     },
+    getAllConsumers: function(clusterId, callback) {
+        jQuery
+            .getJSON('/api/cluster/' + clusterId + '/consumers', '', callback)
+            .fail(ApiClient.defaultErrorHandler);
+    },
     createTopic: function(clusterId, name, partitions, replicas, callback) {
         var payload = JSON.stringify({
             name: name,

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
@@ -125,7 +125,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/api/cluster/*/modify/**",
 
                 // Remove consumer group
-                "/api/cluster/*/remove/**"
+                "/cluster/*/consumer/remove"
 
             ).hasRole("ADMIN")
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
@@ -122,7 +122,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/api/cluster/*/create/**",
 
                 // Modify topic
-                "/api/cluster/*/modify/**"
+                "/api/cluster/*/modify/**",
+
+                // Remove consumer group
+                "/api/cluster/*/remove/**"
+
             ).hasRole("ADMIN")
 
             // All other requests must be authenticated

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
@@ -125,7 +125,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/api/cluster/*/modify/**",
 
                 // Remove consumer group
-                "/cluster/*/consumer/remove"
+                "/api/cluster/*/consumer/remove"
 
             ).hasRole("ADMIN")
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -43,6 +43,7 @@ import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ApiErrorResponse;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConfigItem;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupDetails;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupIdentifier;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupOffsets;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.CreateTopic;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
@@ -441,6 +442,47 @@ public class ApiController extends BaseController {
 
             // Now get details about all of em.
             return operations.getConsumerGroupDetails(stringIds);
+        } catch (final Exception exception) {
+            throw new ApiException("ClusterNodes", exception);
+        }
+    }
+
+    /**
+     * GET Retrieve details about a single specific consumer.
+     */
+    @ResponseBody
+    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/details", method = RequestMethod.GET, produces = "application/json")
+    public ConsumerGroupDetails getConsumerDetails(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+        // Retrieve cluster
+        final Cluster cluster = retrieveClusterById(id);
+
+        try (final KafkaOperations operations = createOperationsClient(cluster)) {
+            final List<String> stringIds = new ArrayList<>();
+            stringIds.add(consumerGroupId);
+
+            // Now get details about all of em.
+            final List<ConsumerGroupDetails> detailsList = operations.getConsumerGroupDetails(stringIds);
+            if (detailsList.isEmpty()) {
+                throw new RuntimeException("Unable to find consumer group id " + consumerGroupId);
+            }
+
+            return detailsList.get(0);
+        } catch (final Exception exception) {
+            throw new ApiException("ClusterNodes", exception);
+        }
+    }
+
+    /**
+     * GET Retrieve offsets for a specific consumer group id.
+     */
+    @ResponseBody
+    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/offsets", method = RequestMethod.GET, produces = "application/json")
+    public ConsumerGroupOffsets getConsumerOffsets(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+        // Retrieve cluster
+        final Cluster cluster = retrieveClusterById(id);
+
+        try (final KafkaOperations operations = createOperationsClient(cluster)) {
+            return operations.getConsumerGroupOffsets(consumerGroupId);
         } catch (final Exception exception) {
             throw new ApiException("ClusterNodes", exception);
         }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -32,6 +32,7 @@ import org.sourcelab.kafka.webview.ui.controller.api.requests.ConsumerRemoveRequ
 import org.sourcelab.kafka.webview.ui.controller.api.requests.CreateTopicRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.ModifyTopicConfigRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.responses.ResultResponse;
+import org.sourcelab.kafka.webview.ui.manager.encryption.Sha1Tools;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperations;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperationsFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.SessionIdentifier;
@@ -584,7 +585,7 @@ public class ApiController extends BaseController {
      * Creates a WebKafkaConsumer instance.
      */
     private WebKafkaConsumer setup(final View view, final Collection<FilterDefinition> filterDefinitions) {
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(
+        final SessionIdentifier sessionIdentifier = SessionIdentifier.newWebIdentifier(
             getLoggedInUserId(),
             getLoggedInUserSessionId()
         );

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -32,6 +32,7 @@ import org.sourcelab.kafka.webview.ui.controller.api.requests.ConsumerRemoveRequ
 import org.sourcelab.kafka.webview.ui.controller.api.requests.CreateTopicRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.ModifyTopicConfigRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.responses.ResultResponse;
+import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaConsumerFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperations;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperationsFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.SessionIdentifier;
@@ -44,6 +45,7 @@ import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConfigItem;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupDetails;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupIdentifier;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupOffsets;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupOffsetsWithTailPositions;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.CreateTopic;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
@@ -483,6 +485,22 @@ public class ApiController extends BaseController {
 
         try (final KafkaOperations operations = createOperationsClient(cluster)) {
             return operations.getConsumerGroupOffsets(consumerGroupId);
+        } catch (final Exception exception) {
+            throw new ApiException("ClusterNodes", exception);
+        }
+    }
+
+    /**
+     * GET Retrieve offsets for a specific consumer group id with tail positions.
+     */
+    @ResponseBody
+    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/offsetsAndTailPositions", method = RequestMethod.GET, produces = "application/json")
+    public ConsumerGroupOffsetsWithTailPositions getConsumerOffsetsWithTailPositions(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+        // Retrieve cluster
+        final Cluster cluster = retrieveClusterById(id);
+
+        try (final KafkaOperations operations = createOperationsClient(cluster)) {
+            return operations.getConsumerGroupOffsetsWithTailOffsets(consumerGroupId);
         } catch (final Exception exception) {
             throw new ApiException("ClusterNodes", exception);
         }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -40,6 +40,7 @@ import org.sourcelab.kafka.webview.ui.manager.kafka.WebKafkaConsumerFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.config.FilterDefinition;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ApiErrorResponse;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConfigItem;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupIdentifier;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.CreateTopic;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
@@ -395,6 +396,23 @@ public class ApiController extends BaseController {
         final String[] options = filter.getOptions().split(",");
 
         return options;
+    }
+
+    /**
+     * GET Options for a specific filter.
+     */
+    @ResponseBody
+    @RequestMapping(path = "/cluster/{id}/consumers", method = RequestMethod.GET, produces = "application/json")
+    public List<ConsumerGroupIdentifier> listConsumers(@PathVariable final Long id) {
+
+        // Retrieve cluster
+        final Cluster cluster = retrieveClusterById(id);
+
+        try (final KafkaOperations operations = createOperationsClient(cluster)) {
+            return operations.listConsumers();
+        } catch (final Exception exception) {
+            throw new ApiException("ClusterNodes", exception);
+        }
     }
 
     /**

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -32,7 +32,6 @@ import org.sourcelab.kafka.webview.ui.controller.api.requests.ConsumerRemoveRequ
 import org.sourcelab.kafka.webview.ui.controller.api.requests.CreateTopicRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.ModifyTopicConfigRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.responses.ResultResponse;
-import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaConsumerFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperations;
 import org.sourcelab.kafka.webview.ui.manager.kafka.KafkaOperationsFactory;
 import org.sourcelab.kafka.webview.ui.manager.kafka.SessionIdentifier;

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -28,6 +28,7 @@ import org.sourcelab.kafka.webview.ui.controller.BaseController;
 import org.sourcelab.kafka.webview.ui.controller.api.exceptions.ApiException;
 import org.sourcelab.kafka.webview.ui.controller.api.exceptions.NotFoundApiException;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.ConsumeRequest;
+import org.sourcelab.kafka.webview.ui.controller.api.requests.ConsumerRemoveRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.CreateTopicRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.requests.ModifyTopicConfigRequest;
 import org.sourcelab.kafka.webview.ui.controller.api.responses.ResultResponse;
@@ -399,7 +400,7 @@ public class ApiController extends BaseController {
     }
 
     /**
-     * GET Options for a specific filter.
+     * GET list all consumer groups for a specific cluster.
      */
     @ResponseBody
     @RequestMapping(path = "/cluster/{id}/consumers", method = RequestMethod.GET, produces = "application/json")
@@ -410,6 +411,26 @@ public class ApiController extends BaseController {
 
         try (final KafkaOperations operations = createOperationsClient(cluster)) {
             return operations.listConsumers();
+        } catch (final Exception exception) {
+            throw new ApiException("ClusterNodes", exception);
+        }
+    }
+
+    /**
+     * POST list all consumer groups for a specific cluster.
+     * This should require ADMIN role.
+     */
+    @ResponseBody
+    @RequestMapping(path = "/cluster/{id}/consumer/remove", method = RequestMethod.POST, produces = "application/json")
+    public boolean removeConsumer(
+        @PathVariable final Long id,
+        @RequestBody final ConsumerRemoveRequest consumerRemoveRequest) {
+
+        // Retrieve cluster
+        final Cluster cluster = retrieveClusterById(consumerRemoveRequest.getClusterId());
+
+        try (final KafkaOperations operations = createOperationsClient(cluster)) {
+            return operations.removeConsumerGroup(consumerRemoveRequest.getConsumerId());
         } catch (final Exception exception) {
             throw new ApiException("ClusterNodes", exception);
         }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -149,8 +149,15 @@ public class ApiController extends BaseController {
      * POST manually set a consumer's offsets.
      */
     @ResponseBody
-    @RequestMapping(path = "/consumer/view/{id}/offsets", method = RequestMethod.POST, produces = "application/json")
-    public ConsumerState setConsumerOffsets(@PathVariable final Long id,  @RequestBody final Map<Integer, Long> partitionOffsetMap) {
+    @RequestMapping(
+        path = "/consumer/view/{id}/offsets",
+        method = RequestMethod.POST,
+        produces = "application/json"
+    )
+    public ConsumerState setConsumerOffsets(
+        @PathVariable final Long id,
+        @RequestBody final Map<Integer, Long> partitionOffsetMap
+    ) {
         // Retrieve View
         final View view = retrieveViewById(id);
 
@@ -166,8 +173,15 @@ public class ApiController extends BaseController {
      * POST manually set a consumer's offsets using a timestamp.
      */
     @ResponseBody
-    @RequestMapping(path = "/consumer/view/{id}/timestamp/{timestamp}", method = RequestMethod.POST, produces = "application/json")
-    public ConsumerState setConsumerOffsetsByTimestamp(@PathVariable final Long id, @PathVariable final Long timestamp) {
+    @RequestMapping(
+        path = "/consumer/view/{id}/timestamp/{timestamp}",
+        method = RequestMethod.POST,
+        produces = "application/json"
+    )
+    public ConsumerState setConsumerOffsetsByTimestamp(
+        @PathVariable final Long id,
+        @PathVariable final Long timestamp
+    ) {
         // Retrieve View
         final View view = retrieveViewById(id);
 
@@ -424,7 +438,11 @@ public class ApiController extends BaseController {
      * GET list all consumer groups for a specific cluster with details about each one.
      */
     @ResponseBody
-    @RequestMapping(path = "/cluster/{id}/consumersAndDetails", method = RequestMethod.GET, produces = "application/json")
+    @RequestMapping(
+        path = "/cluster/{id}/consumersAndDetails",
+        method = RequestMethod.GET,
+        produces = "application/json"
+    )
     public List<ConsumerGroupDetails> listConsumersAndDetails(@PathVariable final Long id) {
 
         // Retrieve cluster
@@ -453,8 +471,15 @@ public class ApiController extends BaseController {
      * GET Retrieve details about a single specific consumer.
      */
     @ResponseBody
-    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/details", method = RequestMethod.GET, produces = "application/json")
-    public ConsumerGroupDetails getConsumerDetails(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+    @RequestMapping(
+        path = "/cluster/{id}/consumer/{consumerGroupId}/details",
+        method = RequestMethod.GET,
+        produces = "application/json"
+    )
+    public ConsumerGroupDetails getConsumerDetails(
+        @PathVariable final Long id,
+        @PathVariable final String consumerGroupId
+    ) {
         // Retrieve cluster
         final Cluster cluster = retrieveClusterById(id);
 
@@ -478,8 +503,15 @@ public class ApiController extends BaseController {
      * GET Retrieve offsets for a specific consumer group id.
      */
     @ResponseBody
-    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/offsets", method = RequestMethod.GET, produces = "application/json")
-    public ConsumerGroupOffsets getConsumerOffsets(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+    @RequestMapping(
+        path = "/cluster/{id}/consumer/{consumerGroupId}/offsets",
+        method = RequestMethod.GET,
+        produces = "application/json"
+    )
+    public ConsumerGroupOffsets getConsumerOffsets(
+        @PathVariable final Long id,
+        @PathVariable final String consumerGroupId
+    ) {
         // Retrieve cluster
         final Cluster cluster = retrieveClusterById(id);
 
@@ -494,8 +526,14 @@ public class ApiController extends BaseController {
      * GET Retrieve offsets for a specific consumer group id with tail positions.
      */
     @ResponseBody
-    @RequestMapping(path = "/cluster/{id}/consumer/{consumerGroupId}/offsetsAndTailPositions", method = RequestMethod.GET, produces = "application/json")
-    public ConsumerGroupOffsetsWithTailPositions getConsumerOffsetsWithTailPositions(@PathVariable final Long id, @PathVariable final String consumerGroupId) {
+    @RequestMapping(
+        path = "/cluster/{id}/consumer/{consumerGroupId}/offsetsAndTailPositions",
+        method = RequestMethod.GET, produces = "application/json"
+    )
+    public ConsumerGroupOffsetsWithTailPositions getConsumerOffsetsWithTailPositions(
+        @PathVariable final Long id,
+        @PathVariable final String consumerGroupId
+    ) {
         // Retrieve cluster
         final Cluster cluster = retrieveClusterById(id);
 
@@ -547,7 +585,10 @@ public class ApiController extends BaseController {
      * Creates a WebKafkaConsumer instance.
      */
     private WebKafkaConsumer setup(final View view, final Collection<FilterDefinition> filterDefinitions) {
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(getLoggedInUserId(), getLoggedInUserSessionId());
+        final SessionIdentifier sessionIdentifier = new SessionIdentifier(
+            getLoggedInUserId(),
+            getLoggedInUserSessionId()
+        );
         return webKafkaConsumerFactory.createWebClient(view, filterDefinitions, sessionIdentifier);
     }
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/ConsumerRemoveRequest.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/ConsumerRemoveRequest.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.controller.api.requests;
 
 /**

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/ConsumerRemoveRequest.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/ConsumerRemoveRequest.java
@@ -1,0 +1,36 @@
+package org.sourcelab.kafka.webview.ui.controller.api.requests;
+
+/**
+ * Defines a request to remove a consumer.
+ */
+public class ConsumerRemoveRequest {
+    private Long clusterId;
+    private String consumerId;
+
+    public ConsumerRemoveRequest() {
+    }
+
+    public Long getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(final Long clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(final String consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerRemoveRequest{"
+            + "clusterId='" + clusterId + '\''
+            + ", consumerId='" + consumerId + '\''
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/cluster/ClusterController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/cluster/ClusterController.java
@@ -165,6 +165,35 @@ public class ClusterController extends BaseController {
         return "cluster/readTopic";
     }
 
+    /**
+     * GET Displays info about a specific consumers group in a cluster.
+     */
+    @RequestMapping(path = "/{clusterId}/consumer/{consumerGroupId:.+}", method = RequestMethod.GET)
+    public String readConsumer(
+        @PathVariable final Long clusterId,
+        @PathVariable final String consumerGroupId,
+        final Model model,
+        final RedirectAttributes redirectAttributes) {
+
+        // Retrieve by id
+        final Cluster cluster = retrieveCluster(clusterId, redirectAttributes);
+        if (cluster == null) {
+            // redirect
+            return "redirect:/";
+        }
+        model.addAttribute("cluster", cluster);
+        model.addAttribute("consumerGroupId", consumerGroupId);
+
+        // Setup breadcrumbs
+        setupBreadCrumbs(model)
+            .addCrumb(cluster.getName(), "/cluster/" + clusterId)
+            .addCrumb("Consumer " + consumerGroupId, null);
+
+
+        // Display template
+        return "cluster/readConsumer";
+    }
+
     private Cluster retrieveCluster(final Long id, final RedirectAttributes redirectAttributes) {
         // Retrieve by id
         final Optional<Cluster> clusterOptional = clusterRepository.findById(id);

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/cluster/ClusterController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/cluster/ClusterController.java
@@ -168,10 +168,10 @@ public class ClusterController extends BaseController {
     /**
      * GET Displays info about a specific consumers group in a cluster.
      */
-    @RequestMapping(path = "/{clusterId}/consumer/{consumerGroupId:.+}", method = RequestMethod.GET)
+    @RequestMapping(path = "/{clusterId}/consumer/{consumerId:.+}", method = RequestMethod.GET)
     public String readConsumer(
         @PathVariable final Long clusterId,
-        @PathVariable final String consumerGroupId,
+        @PathVariable final String consumerId,
         final Model model,
         final RedirectAttributes redirectAttributes) {
 
@@ -182,12 +182,12 @@ public class ClusterController extends BaseController {
             return "redirect:/";
         }
         model.addAttribute("cluster", cluster);
-        model.addAttribute("consumerGroupId", consumerGroupId);
+        model.addAttribute("consumerId", consumerId);
 
         // Setup breadcrumbs
         setupBreadCrumbs(model)
             .addCrumb(cluster.getName(), "/cluster/" + clusterId)
-            .addCrumb("Consumer " + consumerGroupId, null);
+            .addCrumb("Consumer " + consumerId, null);
 
 
         // Display template

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/stream/StreamController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/stream/StreamController.java
@@ -129,7 +129,7 @@ public class StreamController extends BaseController {
         // Build a session identifier
         final long userId = getLoggedInUserId(headerAccessor);
         final String sessionId = headerAccessor.getSessionId();
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(userId, sessionId);
+        final SessionIdentifier sessionIdentifier = SessionIdentifier.newStreamIdentifier(userId, sessionId);
 
         // Override settings
         final ViewCustomizer viewCustomizer = new ViewCustomizer(view, consumeRequest);
@@ -155,7 +155,7 @@ public class StreamController extends BaseController {
         // Request a pause
         final long userId = getLoggedInUserId(headerAccessor);
         final String sessionId = headerAccessor.getSessionId();
-        webSocketConsumersManager.pauseConsumer(viewId, new SessionIdentifier(userId, sessionId));
+        webSocketConsumersManager.pauseConsumer(viewId, SessionIdentifier.newStreamIdentifier(userId, sessionId));
         return "{success: true}";
     }
 
@@ -171,7 +171,7 @@ public class StreamController extends BaseController {
         // Request Resume
         final long userId = getLoggedInUserId(headerAccessor);
         final String sessionId = headerAccessor.getSessionId();
-        webSocketConsumersManager.resumeConsumer(viewId, new SessionIdentifier(userId, sessionId));
+        webSocketConsumersManager.resumeConsumer(viewId, SessionIdentifier.newStreamIdentifier(userId, sessionId));
         return "{success: true}";
     }
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactory.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactory.java
@@ -55,6 +55,7 @@ public class KafkaAdminFactory {
      * Create a new AdminClient instance.
      * @param clusterConfig What cluster to connect to.
      * @param clientId What clientId to associate the connection with.
+     * @return AdminClient instance.
      */
     public AdminClient create(final ClusterConfig clusterConfig, final String clientId) {
         // Create a map
@@ -64,6 +65,12 @@ public class KafkaAdminFactory {
         return KafkaAdminClient.create(config);
     }
 
+    /**
+     * Create a new KafkaConsumer instance.
+     * @param clusterConfig What cluster to connect to.
+     * @param clientId What clientId to associate the connection with.
+     * @return KafkaConsumer instance.
+     */
     public KafkaConsumer<String, String> createConsumer(final ClusterConfig clusterConfig, final String clientId) {
         // Create a map
         final Map<String, Object> config = buildClientProperties(clusterConfig, clientId);
@@ -76,6 +83,12 @@ public class KafkaAdminFactory {
         return new KafkaConsumer<>(config);
     }
 
+    /**
+     * Utility method to generate the appropriate Kafka client configuration from the ClusterConfig definition.
+     * @param clusterConfig Details about the cluster to connect to.
+     * @param clientId What clientId to associate with connection with.
+     * @return Map of Kafka client properties.
+     */
     private Map<String, Object> buildClientProperties(final ClusterConfig clusterConfig, final String clientId) {
         // Create a map
         final Map<String, Object> config = new HashMap<>();

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactory.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactory.java
@@ -28,7 +28,10 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClusterConfig;
 
 import java.util.HashMap;
@@ -55,6 +58,26 @@ public class KafkaAdminFactory {
      */
     public AdminClient create(final ClusterConfig clusterConfig, final String clientId) {
         // Create a map
+        final Map<String, Object> config = buildClientProperties(clusterConfig, clientId);
+
+        // Create instance.
+        return KafkaAdminClient.create(config);
+    }
+
+    public KafkaConsumer<String, String> createConsumer(final ClusterConfig clusterConfig, final String clientId) {
+        // Create a map
+        final Map<String, Object> config = buildClientProperties(clusterConfig, clientId);
+
+        // Set required deserializer classes.
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        // Create consumer
+        return new KafkaConsumer<>(config);
+    }
+
+    private Map<String, Object> buildClientProperties(final ClusterConfig clusterConfig, final String clientId) {
+        // Create a map
         final Map<String, Object> config = new HashMap<>();
         config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, clusterConfig.getConnectString());
         config.put(AdminClientConfig.CLIENT_ID_CONFIG, clientId);
@@ -67,7 +90,6 @@ public class KafkaAdminFactory {
             config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, keyStoreRootPath + "/" + clusterConfig.getTrustStoreFile());
             config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, clusterConfig.getTrustStorePassword());
         }
-
-        return KafkaAdminClient.create(config);
+        return config;
     }
 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -409,6 +409,10 @@ public class KafkaOperations implements AutoCloseable {
                     ));
                 });
 
+            // Sort list by consumer group id
+            consumerGroupDetails.sort(Comparator.comparing(ConsumerGroupDetails::getConsumerId));
+
+            // Return immutable list.
             return Collections.unmodifiableList(consumerGroupDetails);
         } catch (final InterruptedException | ExecutionException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -84,6 +84,7 @@ public class KafkaOperations implements AutoCloseable {
     /**
      * Constructor.
      * @param adminClient The AdminClient to wrap.
+     * @param consumerClient The KafkaConsumer instance to wrap.
      */
     public KafkaOperations(final AdminClient adminClient, final KafkaConsumer<String, String> consumerClient) {
         this.adminClient = adminClient;
@@ -472,11 +473,11 @@ public class KafkaOperations implements AutoCloseable {
 
         final List<PartitionOffsetWithTailPosition> offsetsWithPartitions = new ArrayList<>();
 
-        for (final Map.Entry<Integer, Long> entry : tailOffsets.getPartitionsToOffsets().entrySet()) {
+        for (final PartitionOffset entry : tailOffsets.getOffsets()) {
             offsetsWithPartitions.add(new PartitionOffsetWithTailPosition(
-                entry.getKey(),
-                consumerGroupOffsets.getOffsetForPartition(entry.getKey()),
-                entry.getValue()
+                entry.getPartition(),
+                consumerGroupOffsets.getOffsetForPartition(entry.getPartition()),
+                entry.getOffset()
             ));
         }
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -299,9 +299,11 @@ public class KafkaOperations implements AutoCloseable {
             results
                 .all()
                 .get()
-                .forEach((result) ->  consumerIds.add(new ConsumerGroupIdentifier(
-                    result.groupId(), result.isSimpleConsumerGroup())
-                ));
+                .forEach((result) ->  {
+                    consumerIds.add(
+                        new ConsumerGroupIdentifier(result.groupId(), result.isSimpleConsumerGroup())
+                    );
+                });
 
             // Sort them by consumer Id.
             consumerIds.sort(Comparator.comparing(ConsumerGroupIdentifier::getId));
@@ -382,14 +384,12 @@ public class KafkaOperations implements AutoCloseable {
                         }));
 
                         // Create new ConsumerGroupDetails for this member
-                        members.add(
-                            new ConsumerGroupDetails.Member(
-                                member.consumerId(),
-                                member.clientId(),
-                                member.host(),
-                                assignedPartitions
-                            )
-                        );
+                        members.add(new ConsumerGroupDetails.Member(
+                            member.consumerId(),
+                            member.clientId(),
+                            member.host(),
+                            assignedPartitions
+                        ));
                     });
 
                     final NodeDetails coordinator = new NodeDetails(
@@ -399,16 +399,14 @@ public class KafkaOperations implements AutoCloseable {
                         value.coordinator().rack()
                     );
 
-                    consumerGroupDetails.add(
-                        new ConsumerGroupDetails(
-                            value.groupId(),
-                            value.isSimpleConsumerGroup(),
-                            value.partitionAssignor(),
-                            value.state().toString(),
-                            members,
-                            coordinator
-                        )
-                    );
+                    consumerGroupDetails.add(new ConsumerGroupDetails(
+                        value.groupId(),
+                        value.isSimpleConsumerGroup(),
+                        value.partitionAssignor(),
+                        value.state().toString(),
+                        members,
+                        coordinator
+                    ));
                 });
 
             return Collections.unmodifiableList(consumerGroupDetails);
@@ -436,11 +434,9 @@ public class KafkaOperations implements AutoCloseable {
                 .get();
 
             for (final Map.Entry<org.apache.kafka.common.TopicPartition, OffsetAndMetadata> entry : partitionsToOffsets.entrySet()) {
-                offsetList.add(
-                    new PartitionOffset(
-                        entry.getKey().partition(), entry.getValue().offset()
-                    )
-                );
+                offsetList.add(new PartitionOffset(
+                    entry.getKey().partition(), entry.getValue().offset()
+                ));
                 if (topic == null) {
                     topic = entry.getKey().topic();
                 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -70,13 +71,20 @@ public class KafkaOperations implements AutoCloseable {
     }
 
     /**
-     * Retrieve all available topics within cluster.
+     * Retrieve all available topics within cluster.  Includes internal topics.
      */
     public TopicList getAvailableTopics() {
         final List<org.sourcelab.kafka.webview.ui.manager.kafka.dto.TopicListing> topicListings = new ArrayList<>();
 
         try {
-            final Collection<TopicListing> results = adminClient.listTopics().listings().get();
+            // We want to show all topics, including internal topics.
+            final ListTopicsOptions listTopicsOptions = new ListTopicsOptions().listInternal(true);
+
+            final Collection<TopicListing> results = adminClient
+                .listTopics(listTopicsOptions)
+                .listings()
+                .get();
+
             for (final TopicListing entry: results) {
                 topicListings.add(
                     new org.sourcelab.kafka.webview.ui.manager.kafka.dto.TopicListing(entry.name(), entry.isInternal())

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
@@ -301,6 +302,23 @@ public class KafkaOperations implements AutoCloseable {
             return Collections.unmodifiableList(consumerIds);
 
         } catch (final InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Removes a consumer's state.
+     * @param id id of consumer group to remove.
+     * @return
+     */
+    public boolean removeConsumerGroup(final String id) {
+        final DeleteConsumerGroupsResult request = adminClient.deleteConsumerGroups(Collections.singleton(id));
+
+        try {
+            request.all().get();
+            return true;
+        } catch (InterruptedException | ExecutionException e) {
+            // TODO Handle this
             throw new RuntimeException(e.getMessage(), e);
         }
     }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -459,6 +459,13 @@ public class KafkaOperations implements AutoCloseable {
         }
     }
 
+    /**
+     * Returns consumer offsets for requested consumer group id along with the associated tail offset positions for
+     * each of those partitions.
+     *
+     * @param consumerGroupId id to retrieve offsets for.
+     * @return ConsumerGroupOffsets
+     */
     public ConsumerGroupOffsetsWithTailPositions getConsumerGroupOffsetsWithTailOffsets(final String consumerGroupId) {
         final ConsumerGroupOffsets consumerGroupOffsets = getConsumerGroupOffsets(consumerGroupId);
         final TailOffsets tailOffsets = getTailOffsets(consumerGroupOffsets.getTopic(), consumerGroupOffsets.getPartitions());
@@ -488,7 +495,12 @@ public class KafkaOperations implements AutoCloseable {
     public TailOffsets getTailOffsets(final String topic) {
         // Determine which partitions exist on the topic
         final TopicDetails topicDetails = getTopicDetails(topic);
-        final List<Integer> partitions = topicDetails.getPartitions().stream().map(PartitionDetails::getPartition).collect(Collectors.toList());
+        final List<Integer> partitions = topicDetails.getPartitions()
+            .stream()
+            .map(PartitionDetails::getPartition)
+            .collect(Collectors.toList());
+
+        // Call method for specific partitions.
         return getTailOffsets(topic, partitions);
     }
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactory.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactory.java
@@ -25,6 +25,7 @@
 package org.sourcelab.kafka.webview.ui.manager.kafka;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.sourcelab.kafka.webview.ui.manager.encryption.SecretManager;
 import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClusterConfig;
 import org.sourcelab.kafka.webview.ui.model.Cluster;
@@ -61,7 +62,8 @@ public class KafkaOperationsFactory {
         // Create new Operational Client
         final ClusterConfig clusterConfig = ClusterConfig.newBuilder(cluster, secretManager).build();
         final AdminClient adminClient = kafkaAdminFactory.create(clusterConfig, clientId);
+        final KafkaConsumer<String, String> kafkaConsumer = kafkaAdminFactory.createConsumer(clusterConfig, clientId);
 
-        return new KafkaOperations(adminClient);
+        return new KafkaOperations(adminClient, kafkaConsumer);
     }
 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactory.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactory.java
@@ -63,7 +63,7 @@ public class WebKafkaConsumerFactory {
     /**
      * Defines the consumerId prefix pre-pended to all consumers.
      */
-    private static final String consumerIdPrefix = "KafkaWebView-Consumer-UserId";
+    private static final String consumerIdPrefix = "UserId";
 
     private final PluginFactory<Deserializer> deserializerPluginFactory;
     private final PluginFactory<RecordFilter> recordFilterPluginFactory;
@@ -141,6 +141,7 @@ public class WebKafkaConsumerFactory {
         final View view,
         final Collection<FilterDefinition> filterDefinitions,
         final SessionIdentifier sessionIdentifier) {
+
         // Construct a consumerId based on user
         final String consumerId = consumerIdPrefix + sessionIdentifier.toString();
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
@@ -1,0 +1,67 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+import java.util.List;
+
+/**
+ * Details about a specific consumer group.
+ */
+public class ConsumerGroupDetails {
+    final String consumerId;
+    final boolean isSimple;
+    final String partitionAssignor;
+    final List<State> states;
+    final List<Member> members;
+
+    public ConsumerGroupDetails(
+        final String consumerId,
+        final boolean isSimple,
+        final String partitionAssignor,
+        final List<State> states,
+        final List<Member> members
+    ) {
+        this.consumerId = consumerId;
+        this.isSimple = isSimple;
+        this.partitionAssignor = partitionAssignor;
+        this.members = members;
+        this.states = states;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public boolean isSimple() {
+        return isSimple;
+    }
+
+    public String getPartitionAssignor() {
+        return partitionAssignor;
+    }
+
+    public List<State> getStates() {
+        return states;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public static class State {
+
+    }
+
+    public static class Member {
+
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupDetails{"
+            + "consumerId='" + consumerId + '\''
+            + ", isSimple=" + isSimple
+            + ", partitionAssignor='" + partitionAssignor + '\''
+            + ", states=" + states
+            + ", members=" + members
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.ArrayList;
@@ -24,7 +48,7 @@ public class ConsumerGroupDetails {
      * @param partitionAssignor How partitions are assigned
      * @param state state of consumer
      * @param members members in the group.
-     * @param coordinator
+     * @param coordinator node that is acting as the coordinator for this group.
      */
     public ConsumerGroupDetails(
         final String consumerId,
@@ -74,6 +98,13 @@ public class ConsumerGroupDetails {
         private final String host;
         private final Set<TopicPartition> assignment;
 
+        /**
+         * Constructor.
+         * @param memberId Consumer group id.
+         * @param clientId Id of the individual member of the group.
+         * @param host host of consumer.
+         * @param assignment what partitions the consumer is assigned.
+         */
         public Member(final String memberId, final String clientId, final String host, final Set<TopicPartition> assignment) {
             this.memberId = memberId;
             this.clientId = clientId;

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupDetails.java
@@ -1,29 +1,44 @@
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Details about a specific consumer group.
  */
 public class ConsumerGroupDetails {
-    final String consumerId;
-    final boolean isSimple;
-    final String partitionAssignor;
-    final List<State> states;
-    final List<Member> members;
+    private final String consumerId;
+    private final boolean isSimple;
+    private final String partitionAssignor;
+    private final String state;
+    private final List<Member> members;
+    private final NodeDetails coordinator;
 
+    /**
+     * Constructor.
+     * @param consumerId consumer group id.
+     * @param isSimple if its a simple consumer group
+     * @param partitionAssignor How partitions are assigned
+     * @param state state of consumer
+     * @param members members in the group.
+     * @param coordinator
+     */
     public ConsumerGroupDetails(
         final String consumerId,
         final boolean isSimple,
         final String partitionAssignor,
-        final List<State> states,
-        final List<Member> members
-    ) {
+        final String state,
+        final List<Member> members,
+        final NodeDetails coordinator) {
         this.consumerId = consumerId;
         this.isSimple = isSimple;
         this.partitionAssignor = partitionAssignor;
-        this.members = members;
-        this.states = states;
+        this.members = Collections.unmodifiableList(new ArrayList<>(members));
+        this.state = state;
+        this.coordinator = coordinator;
     }
 
     public String getConsumerId() {
@@ -38,20 +53,59 @@ public class ConsumerGroupDetails {
         return partitionAssignor;
     }
 
-    public List<State> getStates() {
-        return states;
+    public String getState() {
+        return state;
     }
 
     public List<Member> getMembers() {
         return members;
     }
 
-    public static class State {
-
+    public NodeDetails getCoordinator() {
+        return coordinator;
     }
 
+    /**
+     * Represents a consumer group members details.
+     */
     public static class Member {
+        private final String memberId;
+        private final String clientId;
+        private final String host;
+        private final Set<TopicPartition> assignment;
 
+        public Member(final String memberId, final String clientId, final String host, final Set<TopicPartition> assignment) {
+            this.memberId = memberId;
+            this.clientId = clientId;
+            this.host = host;
+            this.assignment = Collections.unmodifiableSet(new HashSet<>(assignment));
+        }
+
+        public String getMemberId() {
+            return memberId;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public Set<TopicPartition> getAssignment() {
+            return assignment;
+        }
+
+        @Override
+        public String toString() {
+            return "Member{"
+                + "memberId='" + memberId + '\''
+                + ", clientId='" + clientId + '\''
+                + ", host='" + host + '\''
+                + ", assignment=" + assignment
+                + '}';
+        }
     }
 
     @Override
@@ -60,8 +114,9 @@ public class ConsumerGroupDetails {
             + "consumerId='" + consumerId + '\''
             + ", isSimple=" + isSimple
             + ", partitionAssignor='" + partitionAssignor + '\''
-            + ", states=" + states
+            + ", state='" + state + '\''
             + ", members=" + members
+            + ", coordinator=" + coordinator
             + '}';
     }
 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupIdentifier.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupIdentifier.java
@@ -1,0 +1,35 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+/**
+ * Represents information about a consumer group identifier.
+ */
+public class ConsumerGroupIdentifier {
+    private final String id;
+    private final boolean isSimple;
+
+    /**
+     * Constructor.
+     * @param id consumer group id/name.
+     * @param isSimple If its a simple consumer or not.
+     */
+    public ConsumerGroupIdentifier(final String id, final boolean isSimple) {
+        this.id = id;
+        this.isSimple = isSimple;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public boolean isSimple() {
+        return isSimple;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupIdentifier{"
+            + "id='" + id + '\''
+            + ", isSimple=" + isSimple
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupIdentifier.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupIdentifier.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 /**

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
@@ -1,0 +1,80 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Represents details about a consumer group offset positions.
+ */
+public class ConsumerGroupOffsets {
+    private final String consumerGroupId;
+    private final String topic;
+    private final Map<Integer, PartitionOffset> offsetMap;
+
+    /**
+     * Constructor.
+     * @param consumerGroupId id of consumer group.
+     * @param topic name of the topic.
+     * @param offsets details about each partition and offset.
+     */
+    public ConsumerGroupOffsets(final String consumerGroupId, final String topic, final Collection<PartitionOffset> offsets) {
+        this.consumerGroupId = consumerGroupId;
+        this.topic = topic;
+
+        final Map<Integer, PartitionOffset> offsetMap = new HashMap<>();
+        for (final PartitionOffset offset : offsets) {
+            offsetMap.put(
+                offset.getPartition(),
+                offset
+            );
+        }
+        this.offsetMap = Collections.unmodifiableMap(offsetMap);
+    }
+
+    public String getConsumerGroupId() {
+        return consumerGroupId;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public Map<Integer, PartitionOffset> getOffsetMap() {
+        return offsetMap;
+    }
+
+    public List<PartitionOffset> getOffsets() {
+        final List<PartitionOffset> offsetList = new ArrayList<>(offsetMap.values());
+
+        // Sort by partition
+        offsetList.sort((o1, o2) -> Integer.valueOf(o1.getPartition()).compareTo(o2.getPartition()));
+        return Collections.unmodifiableList(offsetList);
+    }
+
+    public long getOffsetForPartition(final int partition) {
+        final Optional<PartitionOffset> offsetOptional = getOffsetMap()
+            .values()
+            .stream()
+            .filter((offset) -> offset.getPartition() == partition)
+            .findFirst();
+
+        if (offsetOptional.isPresent()) {
+            return offsetOptional.get().getOffset();
+        }
+        throw new RuntimeException("Unable to find partition " + partition);
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupOffsets{"
+            + "consumerGroupId='" + consumerGroupId + '\''
+            + ", topic='" + topic + '\''
+            + ", offsetMap=" + offsetMap
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.ArrayList;
@@ -7,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Represents details about a consumer group offset positions.
@@ -48,6 +74,9 @@ public class ConsumerGroupOffsets {
         return offsetMap;
     }
 
+    /**
+     * @return List of offsets.
+     */
     public List<PartitionOffset> getOffsets() {
         final List<PartitionOffset> offsetList = new ArrayList<>(offsetMap.values());
 
@@ -56,6 +85,12 @@ public class ConsumerGroupOffsets {
         return Collections.unmodifiableList(offsetList);
     }
 
+    /**
+     * Get offset for the requested partition.
+     * @param partition id of partition.
+     * @return offset stored
+     * @throws RuntimeException if requested invalid partition.
+     */
     public long getOffsetForPartition(final int partition) {
         final Optional<PartitionOffset> offsetOptional = getOffsetMap()
             .values()
@@ -67,6 +102,14 @@ public class ConsumerGroupOffsets {
             return offsetOptional.get().getOffset();
         }
         throw new RuntimeException("Unable to find partition " + partition);
+    }
+
+    /**
+     * @return Set of all available partitions.
+     */
+    public Set<Integer> getPartitions() {
+        final TreeSet<Integer> partitions = new TreeSet<>(offsetMap.keySet());
+        return Collections.unmodifiableSet(partitions);
     }
 
     @Override

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
@@ -38,18 +38,18 @@ import java.util.TreeSet;
  * Represents details about a consumer group offset positions.
  */
 public class ConsumerGroupOffsets {
-    private final String consumerGroupId;
+    private final String consumerId;
     private final String topic;
     private final Map<Integer, PartitionOffset> offsetMap;
 
     /**
      * Constructor.
-     * @param consumerGroupId id of consumer group.
+     * @param consumerId id of consumer group.
      * @param topic name of the topic.
      * @param offsets details about each partition and offset.
      */
-    public ConsumerGroupOffsets(final String consumerGroupId, final String topic, final Collection<PartitionOffset> offsets) {
-        this.consumerGroupId = consumerGroupId;
+    public ConsumerGroupOffsets(final String consumerId, final String topic, final Collection<PartitionOffset> offsets) {
+        this.consumerId = consumerId;
         this.topic = topic;
 
         final Map<Integer, PartitionOffset> offsetMap = new HashMap<>();
@@ -62,15 +62,15 @@ public class ConsumerGroupOffsets {
         this.offsetMap = Collections.unmodifiableMap(offsetMap);
     }
 
-    public String getConsumerGroupId() {
-        return consumerGroupId;
+    public String getConsumerId() {
+        return consumerId;
     }
 
     public String getTopic() {
         return topic;
     }
 
-    public Map<Integer, PartitionOffset> getOffsetMap() {
+    private Map<Integer, PartitionOffset> getOffsetMap() {
         return offsetMap;
     }
 
@@ -115,7 +115,7 @@ public class ConsumerGroupOffsets {
     @Override
     public String toString() {
         return "ConsumerGroupOffsets{"
-            + "consumerGroupId='" + consumerGroupId + '\''
+            + "consumerId='" + consumerId + '\''
             + ", topic='" + topic + '\''
             + ", offsetMap=" + offsetMap
             + '}';

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsets.java
@@ -70,6 +70,9 @@ public class ConsumerGroupOffsets {
         return topic;
     }
 
+    /**
+     * Marked private to keep from being serialized in responses.
+     */
     private Map<Integer, PartitionOffset> getOffsetMap() {
         return offsetMap;
     }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
@@ -1,0 +1,115 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class ConsumerGroupOffsetsWithTailPositions {
+    private final String consumerId;
+    private final String topic;
+    private final Map<Integer, PartitionOffsetWithTailPosition> offsetMap;
+
+    /**
+     * Constructor.
+     * @param consumerId id of consumer group.
+     * @param topic name of the topic.
+     * @param offsets details about each partition and offset.
+     */
+    public ConsumerGroupOffsetsWithTailPositions(final String consumerId, final String topic, final Collection<PartitionOffsetWithTailPosition> offsets) {
+        this.consumerId = consumerId;
+        this.topic = topic;
+
+        final Map<Integer, PartitionOffsetWithTailPosition> offsetMap = new HashMap<>();
+        for (final PartitionOffsetWithTailPosition offset : offsets) {
+            offsetMap.put(
+                offset.getPartition(),
+                offset
+            );
+        }
+        this.offsetMap = Collections.unmodifiableMap(offsetMap);
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    private Map<Integer, PartitionOffsetWithTailPosition> getOffsetMap() {
+        return offsetMap;
+    }
+
+    /**
+     * @return List of offsets.
+     */
+    public List<PartitionOffsetWithTailPosition> getOffsets() {
+        final List<PartitionOffsetWithTailPosition> offsetList = new ArrayList<>(offsetMap.values());
+
+        // Sort by partition
+        offsetList.sort((o1, o2) -> Integer.valueOf(o1.getPartition()).compareTo(o2.getPartition()));
+        return Collections.unmodifiableList(offsetList);
+    }
+
+    /**
+     * Get offset for the requested partition.
+     * @param partition id of partition.
+     * @return offset stored
+     * @throws RuntimeException if requested invalid partition.
+     */
+    public long getOffsetForPartition(final int partition) {
+        final Optional<PartitionOffsetWithTailPosition> offsetOptional = getOffsetMap()
+            .values()
+            .stream()
+            .filter((offset) -> offset.getPartition() == partition)
+            .findFirst();
+
+        if (offsetOptional.isPresent()) {
+            return offsetOptional.get().getOffset();
+        }
+        throw new RuntimeException("Unable to find partition " + partition);
+    }
+
+    /**
+     * Get offset for the requested partition.
+     * @param partition id of partition.
+     * @return offset stored
+     * @throws RuntimeException if requested invalid partition.
+     */
+    public long getTailOffsetForPartition(final int partition) {
+        final Optional<PartitionOffsetWithTailPosition> offsetOptional = getOffsetMap()
+            .values()
+            .stream()
+            .filter((offset) -> offset.getPartition() == partition)
+            .findFirst();
+
+        if (offsetOptional.isPresent()) {
+            return offsetOptional.get().getTailOffset();
+        }
+        throw new RuntimeException("Unable to find partition " + partition);
+    }
+
+    /**
+     * @return Set of all available partitions.
+     */
+    public Set<Integer> getPartitions() {
+        final TreeSet<Integer> partitions = new TreeSet<>(offsetMap.keySet());
+        return Collections.unmodifiableSet(partitions);
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupOffsetsWithTailPositions{"
+            + "consumerId='" + consumerId + '\''
+            + ", topic='" + topic + '\''
+            + ", offsetMap=" + offsetMap
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.ArrayList;
@@ -10,6 +34,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+/**
+ * Represents details about a consumer group offset positions, including the current tail offset positions for
+ * each partition.
+ */
 public class ConsumerGroupOffsetsWithTailPositions {
     private final String consumerId;
     private final String topic;
@@ -21,18 +49,22 @@ public class ConsumerGroupOffsetsWithTailPositions {
      * @param topic name of the topic.
      * @param offsets details about each partition and offset.
      */
-    public ConsumerGroupOffsetsWithTailPositions(final String consumerId, final String topic, final Collection<PartitionOffsetWithTailPosition> offsets) {
+    public ConsumerGroupOffsetsWithTailPositions(
+        final String consumerId,
+        final String topic,
+        final Iterable<PartitionOffsetWithTailPosition> offsets
+    ) {
         this.consumerId = consumerId;
         this.topic = topic;
 
-        final Map<Integer, PartitionOffsetWithTailPosition> offsetMap = new HashMap<>();
+        final Map<Integer, PartitionOffsetWithTailPosition> copiedMap = new HashMap<>();
         for (final PartitionOffsetWithTailPosition offset : offsets) {
-            offsetMap.put(
+            copiedMap.put(
                 offset.getPartition(),
                 offset
             );
         }
-        this.offsetMap = Collections.unmodifiableMap(offsetMap);
+        this.offsetMap = Collections.unmodifiableMap(copiedMap);
     }
 
     public String getConsumerId() {
@@ -43,7 +75,7 @@ public class ConsumerGroupOffsetsWithTailPositions {
         return topic;
     }
 
-    private Map<Integer, PartitionOffsetWithTailPosition> getOffsetMap() {
+    public Map<Integer, PartitionOffsetWithTailPosition> getOffsetMap() {
         return offsetMap;
     }
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/ConsumerGroupOffsetsWithTailPositions.java
@@ -25,7 +25,6 @@
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -75,7 +74,10 @@ public class ConsumerGroupOffsetsWithTailPositions {
         return topic;
     }
 
-    public Map<Integer, PartitionOffsetWithTailPosition> getOffsetMap() {
+    /**
+     * Marked private to keep from being serialized in responses.
+     */
+    private Map<Integer, PartitionOffsetWithTailPosition> getOffsetMap() {
         return offsetMap;
     }
 
@@ -123,7 +125,7 @@ public class ConsumerGroupOffsetsWithTailPositions {
             .findFirst();
 
         if (offsetOptional.isPresent()) {
-            return offsetOptional.get().getTailOffset();
+            return offsetOptional.get().getTail();
         }
         throw new RuntimeException("Unable to find partition " + partition);
     }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffset.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffset.java
@@ -25,7 +25,7 @@
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 /**
- * Represents metadata about an offset stored on a particular partition.
+ * Represents metadata about a consumer offset stored on a particular partition.
  */
 public class PartitionOffset {
     private final int partition;

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
@@ -31,15 +31,15 @@ package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 public class PartitionOffsetWithTailPosition {
     private final int partition;
     private final long offset;
-    private final long tailOffset;
+    private final long tail;
 
     /**
      * Constructor.
      */
-    public PartitionOffsetWithTailPosition(final int partition, final long offset, final long tailOffset) {
+    public PartitionOffsetWithTailPosition(final int partition, final long offset, final long tail) {
         this.partition = partition;
         this.offset = offset;
-        this.tailOffset = tailOffset;
+        this.tail = tail;
     }
 
     public int getPartition() {
@@ -50,8 +50,8 @@ public class PartitionOffsetWithTailPosition {
         return offset;
     }
 
-    public long getTailOffset() {
-        return tailOffset;
+    public long getTail() {
+        return tail;
     }
 
     @Override
@@ -59,7 +59,7 @@ public class PartitionOffsetWithTailPosition {
         return "PartitionOffsetWithTailPosition{"
             + "partition=" + partition
             + ", offset=" + offset
-            + ", tailOffset=" + tailOffset
+            + ", tail=" + tail
             + '}';
     }
 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
@@ -1,5 +1,33 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
+/**
+ * Represents metadata about a consumer offset stored on a particular partition along with the current
+ * tail offset position for the same partition.
+ */
 public class PartitionOffsetWithTailPosition {
     private final int partition;
     private final long offset;

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/PartitionOffsetWithTailPosition.java
@@ -1,0 +1,37 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+public class PartitionOffsetWithTailPosition {
+    private final int partition;
+    private final long offset;
+    private final long tailOffset;
+
+    /**
+     * Constructor.
+     */
+    public PartitionOffsetWithTailPosition(final int partition, final long offset, final long tailOffset) {
+        this.partition = partition;
+        this.offset = offset;
+        this.tailOffset = tailOffset;
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public long getTailOffset() {
+        return tailOffset;
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionOffsetWithTailPosition{"
+            + "partition=" + partition
+            + ", offset=" + offset
+            + ", tailOffset=" + tailOffset
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
@@ -1,0 +1,39 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Mapping of partitions on a topic to their tail positions.
+ */
+public class TailOffsets {
+    private final String topic;
+    private final Map<Integer, Long> partitionsToOffsets;
+
+    public TailOffsets(final String topic, final Map<Integer, Long> partitionsToOffsets) {
+        this.topic = topic;
+        final Map<Integer, Long> mapping = new HashMap<>(partitionsToOffsets);
+        this.partitionsToOffsets = Collections.unmodifiableMap(mapping);
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public Map<Integer, Long> getPartitionsToOffsets() {
+        return partitionsToOffsets;
+    }
+
+    public long getTailOffsetForPartition(final int partitionId) {
+        if (!partitionsToOffsets.containsKey(partitionId)) {
+            throw new IllegalArgumentException("Invalid partitionId " + partitionId);
+        }
+        return partitionsToOffsets.get(partitionId);
+    }
+
+    public Set<Integer> getPartitions() {
+        return partitionsToOffsets.keySet();
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
@@ -24,7 +24,6 @@
 
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.Collections;
@@ -12,6 +36,11 @@ public class TailOffsets {
     private final String topic;
     private final Map<Integer, Long> partitionsToOffsets;
 
+    /**
+     * Constructor.
+     * @param topic Name of the topic.
+     * @param partitionsToOffsets Maps partitionId to the current tail offset on that partition.
+     */
     public TailOffsets(final String topic, final Map<Integer, Long> partitionsToOffsets) {
         this.topic = topic;
         final Map<Integer, Long> mapping = new HashMap<>(partitionsToOffsets);
@@ -26,6 +55,13 @@ public class TailOffsets {
         return partitionsToOffsets;
     }
 
+    /**
+     * For a given partition, return the tail offset.
+     * @param partitionId The partition to retrieve the tail offset for.
+     * @return The current tail offset position.
+     *
+     * @throws IllegalArgumentException if passed an invalid partitionId.
+     */
     public long getTailOffsetForPartition(final int partitionId) {
         if (!partitionsToOffsets.containsKey(partitionId)) {
             throw new IllegalArgumentException("Invalid partitionId " + partitionId);

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TailOffsets.java
@@ -24,10 +24,14 @@
 
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Mapping of partitions on a topic to their tail positions.
@@ -51,8 +55,25 @@ public class TailOffsets {
         return topic;
     }
 
-    public Map<Integer, Long> getPartitionsToOffsets() {
+    /**
+     * Marked private to avoid being serialized in responses.
+     */
+    private Map<Integer, Long> getPartitionsToOffsets() {
         return partitionsToOffsets;
+    }
+
+    /**
+     * Sorted list of offsets.
+     * @return Immutable list of offsets.
+     */
+    public List<PartitionOffset> getOffsets() {
+        final List<PartitionOffset> offsets = partitionsToOffsets.entrySet()
+            .stream()
+            .map((entry) -> new PartitionOffset(entry.getKey(), entry.getValue()))
+            .sorted(Comparator.comparingInt(PartitionOffset::getPartition))
+            .collect(Collectors.toList());
+
+        return Collections.unmodifiableList(offsets);
     }
 
     /**
@@ -62,7 +83,7 @@ public class TailOffsets {
      *
      * @throws IllegalArgumentException if passed an invalid partitionId.
      */
-    public long getTailOffsetForPartition(final int partitionId) {
+    public long getOffsetForPartition(final int partitionId) {
         if (!partitionsToOffsets.containsKey(partitionId)) {
             throw new IllegalArgumentException("Invalid partitionId " + partitionId);
         }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicPartition.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicPartition.java
@@ -1,0 +1,51 @@
+package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
+
+import java.util.Objects;
+
+/**
+ * Represents a partition on a specific topic.
+ */
+public class TopicPartition {
+    private final String topic;
+    private final int partition;
+
+    /**
+     * Constructor.
+     * @param topic Name of the topic.
+     * @param partition partition id.
+     */
+    public TopicPartition(final String topic, final int partition) {
+        this.topic = topic;
+        this.partition = partition;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public String toString() {
+        return "TopicPartition{"
+            + "topic='" + topic + '\''
+            + ", partition=" + partition
+            + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final TopicPartition that = (TopicPartition) o;
+        return partition == that.partition &&
+            Objects.equals(topic, that.topic);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topic, partition);
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicPartition.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicPartition.java
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018 SourceLab.org (https://github.com/Crim/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.sourcelab.kafka.webview.ui.manager.kafka.dto;
 
 import java.util.Objects;
@@ -36,12 +60,15 @@ public class TopicPartition {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final TopicPartition that = (TopicPartition) o;
-        return partition == that.partition &&
-            Objects.equals(topic, that.topic);
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        final TopicPartition that = (TopicPartition) other;
+        return partition == that.partition && Objects.equals(topic, that.topic);
     }
 
     @Override

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -90,11 +90,53 @@
                         jQuery('#topics-table').toggle(true);
                     }
                 },
+
+                // Handle all consumers results ajax result
+                handleConsumers: function(results) {
+                    // Clear topics table
+                    var table = jQuery('#consumers-tbody');
+                    jQuery(table).empty();
+
+                    // Get and compile template
+                    var source   = jQuery('#consumers-template').html();
+                    var template = Handlebars.compile(source);
+
+                    jQuery.each(results, function(index, result) {
+                        // Generate html from template
+                        var properties = {
+                            id: result.id,
+                            encodedId: encodeURIComponent(result.id),
+                            clusterId: ClusterInfo.clusterId
+                        };
+                        var resultHtml = template(properties);
+
+                        // Append it to our table
+                        jQuery(table).append(resultHtml);
+                    });
+
+                    // Hide loader
+                    jQuery('#consumers-loader').toggle(false);
+
+                    if (results.length == 0) {
+                        jQuery('#consumers-no-results').toggle(true);
+                    } else {
+                        jQuery('#consumers-no-results').toggle(false);
+                        jQuery('#consumers-table').toggle(true);
+                    }
+                },
+
                 loadTopics: function() {
                     // Fire off request to get topic details
                     ApiClient.getAllTopicsDetails(ClusterInfo.clusterId, function(results) {
                         // Handle results
                         ClusterInfo.handleAllTopicsDetails(results);
+                    });
+                },
+                loadConsumers: function() {
+                    // Fire off request to get consumer details
+                    ApiClient.getAllConsumers(ClusterInfo.clusterId, function(results) {
+                        // Handle results
+                        ClusterInfo.handleConsumers(results);
                     });
                 },
                 // Handle submitting new topic form.
@@ -135,6 +177,9 @@
 
                     // Fire off request to get topic details
                     ClusterInfo.loadTopics();
+
+                    // Fire off request to get consumers
+                    ClusterInfo.loadConsumers();
                 });
             });
         </script>
@@ -232,6 +277,48 @@
             </div>
         </div>
 
+        <!-- Consumers -->
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-header">
+                        <i class="fa fa-align-justify"></i>
+                        Cluster <strong th:text="${cluster.name}"></strong> Consumers
+                    </div>
+                    <div class="card-body">
+                        <!-- Display Loader First -->
+                        <div class="alert alert-light" role="alert" id="consumers-loader" style="display: block;">
+                            <div class="progress">
+                                <div
+                                    class="progress-bar progress-bar-striped progress-bar-animated"
+                                    role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: 100%">
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- No Results Found -->
+                        <div class="alert alert-light" role="alert" id="consumers-no-results" style="display: none;">
+                            <h4 class="alert-heading">No Consumers Found</h4>
+                            <p>Looks like we couldn't find any consumers!</p>
+                        </div>
+
+                        <!-- Hide Results Table -->
+                        <table class="table table-bordered table-striped table-sm" id="consumers-table" style="display: none;">
+                            <thead>
+                            <tr>
+                                <th>Consumer Id</th>
+                                <th sec:authorize="hasRole('ROLE_ADMIN')">Delete</th>
+                            </tr>
+                            </thead>
+                            <tbody id="consumers-tbody">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Nodes Template -->
         <script id="nodes-template" type="text/x-handlebars-template">
             <tr>
@@ -267,6 +354,20 @@
                     {{#if internal}}
                         <span class="badge badge-info">Internal topic</span>
                     {{/if}}
+                </td>
+            </tr>
+        </script>
+
+        <!-- Topics Details Template -->
+        <script id="consumers-template" type="text/x-handlebars-template">
+            <tr>
+                <td>
+                    <a href="/cluster/{{clusterId}}/consumer/{{encodedId}}">
+                        {{id}}
+                    </a>
+                </td>
+                <td sec:authorize="hasRole('ROLE_ADMIN')">
+                    [TODO]
                 </td>
             </tr>
         </script>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -48,6 +48,7 @@
 
                     if (results.length == 0) {
                         jQuery('#nodes-no-results').toggle(true);
+                        jQuery('#nodes-table').toggle(false);
                     } else {
                         jQuery('#nodes-no-results').toggle(false);
                         jQuery('#nodes-table').toggle(true);
@@ -85,6 +86,7 @@
 
                     if (results.length == 0) {
                         jQuery('#topics-no-results').toggle(true);
+                        jQuery('#topics-table').toggle(false);
                     } else {
                         jQuery('#topics-no-results').toggle(false);
                         jQuery('#topics-table').toggle(true);
@@ -119,6 +121,7 @@
 
                     if (results.length == 0) {
                         jQuery('#consumers-no-results').toggle(true);
+                        jQuery('#consumers-table').toggle(false);
                     } else {
                         jQuery('#consumers-no-results').toggle(false);
                         jQuery('#consumers-table').toggle(true);
@@ -138,6 +141,19 @@
                         // Handle results
                         ClusterInfo.handleConsumers(results);
                     });
+                },
+                removeConsumer: function(consumerId) {
+                    if (!confirm('Are you sure you want to remove this consumer group?')) {
+                        return;
+                    }
+                    ApiClient.removeConsumer(ClusterInfo.clusterId, consumerId, function(result) {
+                        UITools.showSuccess('Successfully remove consumer group.');
+
+                        // Display success
+                        // On success reload consumers
+                        ClusterInfo.loadConsumers();
+                    });
+
                 },
                 // Handle submitting new topic form.
                 createNewTopic: function() {
@@ -277,13 +293,13 @@
             </div>
         </div>
 
-        <!-- Consumers -->
+        <!-- Consumer Groups -->
         <div class="row">
             <div class="col-lg-12">
                 <div class="card">
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
-                        Cluster <strong th:text="${cluster.name}"></strong> Consumers
+                        Cluster <strong th:text="${cluster.name}"></strong> Consumer Groups
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -307,7 +323,7 @@
                         <table class="table table-bordered table-striped table-sm" id="consumers-table" style="display: none;">
                             <thead>
                             <tr>
-                                <th>Consumer Id</th>
+                                <th>Consumer Group</th>
                                 <th sec:authorize="hasRole('ROLE_ADMIN')">Delete</th>
                             </tr>
                             </thead>
@@ -367,7 +383,7 @@
                     </a>
                 </td>
                 <td sec:authorize="hasRole('ROLE_ADMIN')">
-                    [TODO]
+                    <a href="#" onclick="ClusterInfo.removeConsumer('{{id}}'); return false;">Remove?</a>
                 </td>
             </tr>
         </script>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -104,10 +104,26 @@
                     var template = Handlebars.compile(source);
 
                     jQuery.each(results, function(index, result) {
+                        // Collect unique topics
+                        var topics = [];
+                        jQuery.each(result.members, function(index, member) {
+                            // Loop thru each assignment
+                            jQuery.each(member.assignment, function(index, assigned) {
+                                topics.push(assigned.topic);
+                            });
+                        });
+
+                        var uniqueTopics = topics.filter(function (value, index, self) {
+                            return self.indexOf(value) === index;
+                        });
+
                         // Generate html from template
                         var properties = {
-                            id: result.id,
-                            encodedId: encodeURIComponent(result.id),
+                            id: result.consumerId,
+                            encodedId: encodeURIComponent(result.consumerId),
+                            topic: uniqueTopics,
+                            state: result.state,
+                            numberOfMembers: result.members.length,
                             clusterId: ClusterInfo.clusterId
                         };
                         var resultHtml = template(properties);
@@ -137,7 +153,7 @@
                 },
                 loadConsumers: function() {
                     // Fire off request to get consumer details
-                    ApiClient.getAllConsumers(ClusterInfo.clusterId, function(results) {
+                    ApiClient.getAllConsumersWithDetails(ClusterInfo.clusterId, function(results) {
                         // Handle results
                         ClusterInfo.handleConsumers(results);
                     });
@@ -324,7 +340,10 @@
                             <thead>
                             <tr>
                                 <th>Consumer Group</th>
-                                <th sec:authorize="hasRole('ROLE_ADMIN')">Delete</th>
+                                <th>Topic</th>
+                                <th>State</th>
+                                <th>Members</th>
+                                <th sec:authorize="hasRole('ROLE_ADMIN')" class="text-right">Action</th>
                             </tr>
                             </thead>
                             <tbody id="consumers-tbody">
@@ -382,8 +401,28 @@
                         {{id}}
                     </a>
                 </td>
-                <td sec:authorize="hasRole('ROLE_ADMIN')">
-                    <a href="#" onclick="ClusterInfo.removeConsumer('{{id}}'); return false;">Remove?</a>
+                <td>
+                    {{topic}}
+                </td>
+                <td>
+                    {{state}}
+                </td>
+                <td>
+                    {{numberOfMembers}}
+                </td>
+                <td sec:authorize="hasRole('ROLE_ADMIN')" class="text-right">
+                    <div class="dropdown">
+                        <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Actions
+                        </button>
+                        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton" x-placement="bottom-start" style="position: absolute; transform: translate3d(29px, 31px, 0px); top: 0px; left: 0px; will-change: transform;">
+
+                            <button class="dropdown-item" onclick="ClusterInfo.removeConsumer('{{id}}'); return false;">
+                                <i class="fa fa-remove"></i>
+                                Delete
+                            </button>
+                        </div>
+                    </div>
                 </td>
             </tr>
         </script>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -20,8 +20,20 @@
                 clusterName: '[[${cluster.name}]]',
                 consumerId: '[[${consumerId}]]',
 
+                // Holds reference to last consumer membership data.
+                lastMembershipDetails: [],
+
+                // Holds reference to last refreshed offset data
+                lastOffsetData: [],
+
                 // Refresh ConsumerDetails
                 refreshConsumerDetails: function() {
+                    // Show loaders
+                    jQuery('#consumer-details-loader').toggle(true);
+                    jQuery('#consumer-details-table').toggle(false);
+                    jQuery('#consumer-membership-loader').toggle(true);
+                    jQuery('#consumer-membership-table').toggle(false);
+
                     // Request Cluster Information
                     ApiClient.getConsumerDetails(ConsumerInfo.clusterId, ConsumerInfo.consumerId, ConsumerInfo.handleConsumerDetails);
                 },
@@ -74,11 +86,11 @@
                     // Hide loaders
                     jQuery('#consumer-details-loader').toggle(false);
                     jQuery('#consumer-details-table').toggle(true);
-
-                    // Setup timer to refresh ConsumerDetails every 15 seconds
-                    setTimeout(ConsumerInfo.refreshConsumerDetails, 15 * 1000);
                 },
                 handleMembershipDetails: function(members) {
+                    // Save reference.
+                    ConsumerInfo.lastMembershipDetails = members;
+
                     // Clear consumer details table
                     var table = jQuery('#consumer-membership-tbody');
                     jQuery(table).empty();
@@ -115,6 +127,7 @@
                         jQuery(table).append(resultHtml);
                     });
 
+                    // Hide loaders
                     jQuery('#consumer-membership-loader').toggle(false);
                     jQuery('#consumer-membership-table').toggle(true);
                 },
@@ -122,8 +135,68 @@
                 // Refresh ConsumerOffsets
                 refreshConsumerOffsets: function() {
                     ApiClient.getConsumerOffsets(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
-                        console.log(results);
+                        ConsumerInfo.handleConsumerOffsets(results);
                     });
+                },
+
+                // Handle ConsumerOffsets Results
+                handleConsumerOffsets: function(results) {
+                    console.log(results);
+
+                    // Get consumer offsets table
+                    var table = jQuery('#consumer-offsets-tbody');
+
+                    // Get and compile template
+                    var source   = jQuery('#consumer-offsets-template').html();
+                    var template = Handlebars.compile(source);
+
+                    // Process each partition
+                    jQuery.each(results.offsets, function(index, offsetData) {
+                        // Generate html from template
+                        var properties = {
+                            partition: offsetData.partition,
+                            memberId: ConsumerInfo.findAssignedMemberForPartition(offsetData.partition),
+                            tail: "TODO",
+                            position: offsetData.offset
+                        };
+                        var resultHtml = template(properties);
+
+                        // Look for existing row
+                        var row = jQuery("#partition-" + offsetData.partition);
+                        if (row.length > 0) {
+                            row.replaceWith(resultHtml);
+                        } else {
+                            // Append it to our table
+                            jQuery(table).append(resultHtml);
+                        }
+                    });
+
+                    // Hide loaders
+                    jQuery('#consumer-offsets-loader').toggle(false);
+                    jQuery('#consumer-offsets-table').toggle(true);
+                },
+
+                // Attempts to map partition to its assigned consumer id.
+                findAssignedMemberForPartition: function(partitionId) {
+                    var returnString = null;
+
+                    jQuery.each(ConsumerInfo.lastMembershipDetails, function(index, member) {
+                        console.log("Looking at member")
+                        jQuery.each(member.assignment, function(index, assigned) {
+                            if (assigned.partition == partitionId) {
+                                returnString = member.memberId;
+                                return false;
+                            }
+                        });
+                        // Break out of loop if we found what we were looking for.
+                        if (returnString != null) {
+                            return false;
+                        }
+                    });
+                    if (returnString == null) {
+                        return "Querying...";
+                    }
+                    return returnString;
                 },
 
                 toggleMembershipDetails: function(el) {
@@ -145,6 +218,13 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Cluster <strong th:text="${cluster.name}"></strong> Consumer <strong th:text="${consumerId}"></strong>
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerDetails(); return false;">
+                                <i class="icon-refresh"></i>
+                                &nbsp;Refresh
+                            </a>
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -181,6 +261,13 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Consumer <strong th:text="${consumerId}"></strong> Membership
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerDetails(); return false;">
+                                <i class="icon-refresh"></i>
+                                &nbsp;Refresh
+                            </a>
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -204,6 +291,51 @@
                             </tr>
                             </thead>
                             <tbody id="consumer-membership-tbody">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Consumer Offsets -->
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-header">
+                        <i class="fa fa-align-justify"></i>
+                        Consumer <strong th:text="${consumerId}"></strong> Positions
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerOffsets(); return false;">
+                                <i class="icon-refresh"></i>
+                                &nbsp;Refresh
+                            </a>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <!-- Display Loader First -->
+                        <div class="alert alert-light" role="alert" id="consumer-offsets-loader" style="display: block;">
+                            <div class="progress">
+                                <div
+                                        class="progress-bar progress-bar-striped progress-bar-animated"
+                                        role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
+                                        style="width: 100%">
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Hide Results Table -->
+                        <table class="table table-bordered table-striped table-sm" id="consumer-offsets-table" style="display: none;">
+                            <thead>
+                            <tr>
+                                <th>Partition</th>
+                                <th>Member Id</th>
+                                <th>Tail Offset</th>
+                                <th>Consumer Offset</th>
+                            </tr>
+                            </thead>
+                            <tbody id="consumer-offsets-tbody">
                             </tbody>
                         </table>
                     </div>
@@ -279,7 +411,7 @@
                 <td colspan="3">
                     <table class="table table-bordered table-striped table-sm">
                         <tr>
-                            <td>Assignments</td>
+                            <td>Assigned Partitions</td>
                             <td>
                                 <ul>
                                     {{#each partitions}}
@@ -292,6 +424,16 @@
                         </tr>
                     </table>
                 </td>
+            </tr>
+        </script>
+
+        <!-- Consumer Offsets Template -->
+        <script id="consumer-offsets-template" type="text/x-handlebars-template">
+            <tr id="partition-{{partition}}">
+                <td>{{partition}}</td>
+                <td>{{memberId}}</td>
+                <td>{{tail}}</td>
+                <td>{{position}}</td>
             </tr>
         </script>
 

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -32,6 +32,10 @@
                 refreshOffsetsTimer: null,
                 refreshDetailsTimer: null,
 
+                // Configuration for refresh rates
+                refreshRateConsumerDetails: 30000,
+                refreshRateConsumerOffsets: 10000,
+
                 // Refresh ConsumerDetails
                 refreshConsumerDetails: function() {
                     if (!ConsumerInfo.autoRefreshConsumerDetails) {
@@ -97,7 +101,7 @@
                     jQuery('#consumer-details-loader').toggle(false);
                     jQuery('#consumer-details-table').toggle(true);
 
-                    ConsumerInfo.refreshDetailsTimer = setTimeout(ConsumerInfo.refreshConsumerDetails, 30000);
+                    ConsumerInfo.refreshDetailsTimer = setTimeout(ConsumerInfo.refreshConsumerDetails, ConsumerInfo.refreshRateConsumerDetails);
                 },
                 handleMembershipDetails: function(members) {
                     // Save reference.
@@ -200,7 +204,7 @@
                     jQuery('#consumer-offsets-table').toggle(true);
 
                     // Refresh every 10 seconds
-                    ConsumerInfo.refreshOffsetsTimer = setTimeout(ConsumerInfo.refreshConsumerOffsets, 10000);
+                    ConsumerInfo.refreshOffsetsTimer = setTimeout(ConsumerInfo.refreshConsumerOffsets, ConsumerInfo.refreshRateConsumerOffsets);
 
                     // Push update to graph
                     ConsumerInfo.updateConsumerPositionsGraph(results.offsets);

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -29,9 +29,15 @@
                 // Toggles for auto-refresh
                 autoRefreshOffsets: true,
                 autoRefreshConsumerDetails: true,
+                refreshOffsetsTimer: null,
+                refreshDetailsTimer: null,
 
                 // Refresh ConsumerDetails
                 refreshConsumerDetails: function() {
+                    if (!ConsumerInfo.autoRefreshConsumerDetails) {
+                        return;
+                    }
+
                     // Show loaders
                     jQuery('#consumer-details-loader').toggle(true);
                     jQuery('#consumer-details-table').toggle(false);
@@ -91,9 +97,7 @@
                     jQuery('#consumer-details-loader').toggle(false);
                     jQuery('#consumer-details-table').toggle(true);
 
-                    if (ConsumerInfo.autoRefreshConsumerDetails) {
-                        setTimeout(ConsumerInfo.refreshConsumerDetails, 30000);
-                    }
+                    ConsumerInfo.refreshDetailsTimer = setTimeout(ConsumerInfo.refreshConsumerDetails, 30000);
                 },
                 handleMembershipDetails: function(members) {
                     // Save reference.
@@ -141,9 +145,10 @@
 
                 // Refresh ConsumerOffsets
                 refreshConsumerOffsets: function() {
-                    ApiClient.getConsumerOffsetsWithTailPositions(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
-                        ConsumerInfo.handleConsumerOffsets(results);
-                    });
+                    if (!ConsumerInfo.autoRefreshOffsets) {
+                        return;
+                    }
+                    ApiClient.getConsumerOffsetsWithTailPositions(ConsumerInfo.clusterId, ConsumerInfo.consumerId, ConsumerInfo.handleConsumerOffsets);
                 },
 
                 // Handle ConsumerOffsets Results
@@ -194,10 +199,8 @@
                     jQuery('#consumer-offsets-loader').toggle(false);
                     jQuery('#consumer-offsets-table').toggle(true);
 
-                    if (ConsumerInfo.autoRefreshOffsets) {
-                        // Refresh every 10 seconds
-                        setTimeout(ConsumerInfo.refreshConsumerOffsets, 10000);
-                    }
+                    // Refresh every 10 seconds
+                    ConsumerInfo.refreshOffsetsTimer = setTimeout(ConsumerInfo.refreshConsumerOffsets, 10000);
                 },
 
                 // Attempts to map partition to its assigned consumer id.
@@ -225,7 +228,8 @@
                 toggleMembershipDetails: function(el) {
                     jQuery(el).next("tr.membership-summary").toggle();
                 },
-                findOffsetDifference : function(partition, newConsumerOffset, newTailOffset) {
+
+                findOffsetDifference: function(partition, newConsumerOffset, newTailOffset) {
                     var results = {
                         consumerDifference: 0,
                         tailDifference: 0,
@@ -248,6 +252,34 @@
                         }
                     });
                     return results;
+                },
+
+                toggleAutoRefreshForConsumerDetails: function(enable) {
+                    ConsumerInfo.autoRefreshConsumerDetails = enable;
+                    clearTimeout(ConsumerInfo.refreshDetailsTimer);
+                    
+                    if (enable) {
+                        ConsumerInfo.refreshConsumerDetails();
+                        jQuery('#disable-refresh-details-toggle').toggle(false);
+                        jQuery('#enable-refresh-details-toggle').toggle(true);
+                    } else {
+                        jQuery('#disable-refresh-details-toggle').toggle(true);
+                        jQuery('#enable-refresh-details-toggle').toggle(false);
+                    }
+                },
+
+                toggleAutoRefreshForConsumerOffsets: function(enable) {
+                    ConsumerInfo.autoRefreshOffsets = enable;
+                    clearTimeout(ConsumerInfo.refreshOffsetsTimer);
+
+                    if (enable) {
+                        ConsumerInfo.refreshConsumerOffsets();
+                        jQuery('#disable-refresh-offsets-toggle').toggle(false);
+                        jQuery('#enable-refresh-offsets-toggle').toggle(true);
+                    } else {
+                        jQuery('#disable-refresh-offsets-toggle').toggle(true);
+                        jQuery('#enable-refresh-offsets-toggle').toggle(false);
+                    }
                 }
             };
 
@@ -265,13 +297,6 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Cluster <strong th:text="${cluster.name}"></strong> Consumer <strong th:text="${consumerId}"></strong>
-
-                        <div class="btn-group float-right" role="group" aria-label="Button group">
-                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerDetails(); return false;">
-                                <i class="icon-refresh"></i>
-                                &nbsp;Refresh
-                            </a>
-                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -310,9 +335,13 @@
                         Consumer <strong th:text="${consumerId}"></strong> Membership
 
                         <div class="btn-group float-right" role="group" aria-label="Button group">
-                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerDetails(); return false;">
+                            <a id="enable-refresh-details-toggle" class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.toggleAutoRefreshForConsumerDetails(false); return false;">
                                 <i class="icon-refresh"></i>
-                                &nbsp;Refresh
+                                &nbsp;Refreshing
+                            </a>
+                            <a id="disable-refresh-details-toggle" class="btn" href="#" style="padding-bottom: 0; display: none;" onclick="ConsumerInfo.toggleAutoRefreshForConsumerDetails(true); return false;">
+                                <i class="icon-control-pause"></i>
+                                &nbsp;Paused
                             </a>
                         </div>
                     </div>
@@ -354,9 +383,13 @@
                         Consumer <strong th:text="${consumerId}"></strong> Positions
 
                         <div class="btn-group float-right" role="group" aria-label="Button group">
-                            <a class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.refreshConsumerOffsets(); return false;">
+                            <a id="enable-refresh-offsets-toggle" class="btn" href="#" style="padding-bottom: 0;" onclick="ConsumerInfo.toggleAutoRefreshForConsumerOffsets(false); return false;">
                                 <i class="icon-refresh"></i>
-                                &nbsp;Refresh
+                                &nbsp;Refreshing
+                            </a>
+                            <a id="disable-refresh-offsets-toggle" class="btn" href="#" style="padding-bottom: 0; display: none;" onclick="ConsumerInfo.toggleAutoRefreshForConsumerOffsets(true); return false;">
+                                <i class="icon-control-pause"></i>
+                                &nbsp;Paused
                             </a>
                         </div>
                     </div>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -166,7 +166,7 @@
                         var differences = ConsumerInfo.findOffsetDifference(
                             offsetData.partition,
                             offsetData.offset,
-                            offsetData.tailOffset
+                            offsetData.tail
                         );
 
                         // Generate html from template
@@ -175,9 +175,9 @@
                             memberId: ConsumerInfo.findAssignedMemberForPartition(offsetData.partition),
                             position: offsetData.offset,
                             positionDiff: differences.consumerDifference,
-                            tail: offsetData.tailOffset,
+                            tail: offsetData.tail,
                             tailDiff: differences.tailDifference,
-                            lag: (offsetData.tailOffset - offsetData.offset),
+                            lag: (offsetData.tail - offsetData.offset),
                             lagDiff: differences.lagDifference
                         };
                         var resultHtml = template(properties);
@@ -242,10 +242,10 @@
                     jQuery.each(ConsumerInfo.lastOffsetData, function(index, offsetData) {
                         if (offsetData.partition == partition) {
                             var newLag = newTailOffset - newConsumerOffset;
-                            var oldLag = offsetData.tailOffset - offsetData.offset;
+                            var oldLag = offsetData.tail - offsetData.offset;
 
                             results.consumerDifference = (newConsumerOffset - offsetData.offset);
-                            results.tailDifference = (newTailOffset - offsetData.tailOffset);
+                            results.tailDifference = (newTailOffset - offsetData.tail);
                             results.lagDifference = (newLag - oldLag);
 
                             return false;

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -257,7 +257,7 @@
                 toggleAutoRefreshForConsumerDetails: function(enable) {
                     ConsumerInfo.autoRefreshConsumerDetails = enable;
                     clearTimeout(ConsumerInfo.refreshDetailsTimer);
-                    
+
                     if (enable) {
                         ConsumerInfo.refreshConsumerDetails();
                         jQuery('#disable-refresh-details-toggle').toggle(false);

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -17,28 +17,282 @@
             // Maintains state of our consumer
             var ConsumerInfo = {
                 clusterId: '[[${cluster.id}]]',
+                clusterName: '[[${cluster.name}]]',
                 consumerId: '[[${consumerId}]]',
 
-                handleConsumerDetails: function(results) {
-                    console.log(results);
+                // Refresh ConsumerDetails
+                refreshConsumerDetails: function() {
+                    // Request Cluster Information
+                    ApiClient.getConsumerDetails(ConsumerInfo.clusterId, ConsumerInfo.consumerId, ConsumerInfo.handleConsumerDetails);
+                },
 
-                    // Hide loader
-                    jQuery('#topic-loader').toggle(false);
+                // Handle results from ConsumerDetails request
+                handleConsumerDetails: function(results) {
+                    // Clear consumer details table
+                    var table = jQuery('#consumer-details-tbody');
+                    jQuery(table).empty();
+
+                    // Get and compile template
+                    var source   = jQuery('#consumer-details-template').html();
+                    var template = Handlebars.compile(source);
+
+                    // Collect unique topics
+                    var topics = [];
+                    jQuery.each(results.members, function(index, member) {
+                        // Loop thru each assignment
+                        jQuery.each(member.assignment, function(index, assigned) {
+                            topics.push(assigned.topic);
+                        });
+                    });
+
+                    var uniqueTopics = topics.filter(function (value, index, self) {
+                        return self.indexOf(value) === index;
+                    });
+
+                    // Generate html from template
+                    var properties = {
+                        clusterName: ConsumerInfo.clusterName,
+                        consumerId: ConsumerInfo.consumerId,
+                        topic: uniqueTopics,
+                        state: results.state,
+                        numberOfMembers: results.members.length,
+                        partitionAssignor: results.partitionAssignor,
+                        isSimple: results.simple,
+                        coordinatorId: results.coordinator.id,
+                        coordinatorHost: results.coordinator.host,
+                        coordinatorPort: results.coordinator.port,
+                        coordinatorRack: results.coordinator.rack
+                    };
+                    var resultHtml = template(properties);
+
+                    // Append it to our table
+                    jQuery(table).append(resultHtml);
+
+                    // Build Membership details
+                    ConsumerInfo.handleMembershipDetails(results.members);
+
+                    // Hide loaders
+                    jQuery('#consumer-details-loader').toggle(false);
+                    jQuery('#consumer-details-table').toggle(true);
+
+                    // Setup timer to refresh ConsumerDetails every 15 seconds
+                    setTimeout(ConsumerInfo.refreshConsumerDetails, 15 * 1000);
+                },
+                handleMembershipDetails: function(members) {
+                    // Clear consumer details table
+                    var table = jQuery('#consumer-membership-tbody');
+                    jQuery(table).empty();
+
+                    // Get and compile template
+                    var source   = jQuery('#consumer-membership-template').html();
+                    var template = Handlebars.compile(source);
+
+                    // Process each member
+                    jQuery.each(members, function(index, member) {
+                        var partitions = [];
+
+                        // Loop thru each assignment
+                        jQuery.each(member.assignment, function(index, assigned) {
+                            partitions.push(assigned.partition);
+                        });
+
+                        // Sort partitions?
+                        partitions.sort(function(a, b)
+                        {
+                            return a - b;
+                        });
+
+                        // Generate html from template
+                        var properties = {
+                            memberId: member.memberId,
+                            partitionCount: member.assignment.length,
+                            hostname: member.host,
+                            partitions: partitions
+                        };
+                        var resultHtml = template(properties);
+
+                        // Append it to our table
+                        jQuery(table).append(resultHtml);
+                    });
+
+                    jQuery('#consumer-membership-loader').toggle(false);
+                    jQuery('#consumer-membership-table').toggle(true);
+                },
+
+                // Refresh ConsumerOffsets
+                refreshConsumerOffsets: function() {
+                    ApiClient.getConsumerOffsets(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
+                        console.log(results);
+                    });
+                },
+
+                toggleMembershipDetails: function(el) {
+                    jQuery(el).next("tr.membership-summary").toggle();
                 }
             };
 
             // On load, fire off ajax request to load results.
             jQuery(document).ready(function() {
-                // Chain initial ajax requests.
-                // Request Cluster Information
-                ApiClient.getConsumerDetails(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
-                    // handle results
-                    ConsumerInfo.handleConsumerDetails(results);
-                });
-                ApiClient.getConsumerOffsets(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
-                   console.log(results);
-                });
+                ConsumerInfo.refreshConsumerDetails();
+                ConsumerInfo.refreshConsumerOffsets();
             });
+        </script>
+
+        <!-- Consumer Details -->
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-header">
+                        <i class="fa fa-align-justify"></i>
+                        Cluster <strong th:text="${cluster.name}"></strong> Consumer <strong th:text="${consumerId}"></strong>
+                    </div>
+                    <div class="card-body">
+                        <!-- Display Loader First -->
+                        <div class="alert alert-light" role="alert" id="consumer-details-loader" style="display: block;">
+                            <div class="progress">
+                                <div
+                                    class="progress-bar progress-bar-striped progress-bar-animated"
+                                    role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: 100%">
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Hide Results Table -->
+                        <table class="table table-bordered table-striped table-sm" id="consumer-details-table" style="display: none;">
+                            <thead>
+                            <tr>
+                                <th>Key</th>
+                                <th>Value</th>
+                            </tr>
+                            </thead>
+                            <tbody id="consumer-details-tbody">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Membership Details -->
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-header">
+                        <i class="fa fa-align-justify"></i>
+                        Consumer <strong th:text="${consumerId}"></strong> Membership
+                    </div>
+                    <div class="card-body">
+                        <!-- Display Loader First -->
+                        <div class="alert alert-light" role="alert" id="consumer-membership-loader" style="display: block;">
+                            <div class="progress">
+                                <div
+                                    class="progress-bar progress-bar-striped progress-bar-animated"
+                                    role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: 100%">
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Hide Results Table -->
+                        <table class="table table-bordered table-striped table-sm" id="consumer-membership-table" style="display: none;">
+                            <thead>
+                            <tr>
+                                <th>Member Id</th>
+                                <th>Partitions</th>
+                                <th>Hostname</th>
+                            </tr>
+                            </thead>
+                            <tbody id="consumer-membership-tbody">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Consumer Details Template -->
+        <script id="consumer-details-template" type="text/x-handlebars-template">
+            <tr>
+                <td><strong>Cluster</strong></td>
+                <td>{{clusterName}}</td>
+            </tr>
+            <tr>
+                <td><strong>Consumer Id</strong></td>
+                <td>{{consumerId}}</td>
+            </tr>
+            <tr>
+                <td><strong>Topic</strong></td>
+                <td>{{topic}}</td>
+            </tr>
+            <tr>
+                <td><strong>State</strong></td>
+                <td>{{state}}</td>
+            </tr>
+            <tr>
+                <td><strong>Members</strong></td>
+                <td>{{numberOfMembers}}</td>
+            </tr>
+            <tr>
+                <td><strong>Coordinator</strong></td>
+                <td>
+                    <ul>
+                        <li>
+                            BrokerId: {{coordinatorId}}
+                        </li>
+                        <li>
+                            Host: {{coordinatorHost}}:{{coordinatorPort}}
+                        </li>
+                        <li>
+                            Rack: {{coordinatorRack}}
+                        </li>
+                    </ul>
+
+                </td>
+            </tr>
+            <tr>
+                <td><strong>Partition Assignor</strong></td>
+                <td>{{partitionAssignor}}</td>
+            </tr>
+            <tr>
+                <td><strong>Simple Consumer</strong></td>
+                <td>
+                    {{#if isSimple}}
+                    <span class="badge badge-success">Yes</span>
+                    {{else}}
+                    <span class="badge badge-warning">No</span>
+                    {{/if}}
+                </td>
+            </tr>
+        </script>
+
+        <!-- Consumer Membership Template -->
+        <script id="consumer-membership-template" type="text/x-handlebars-template">
+            <tr onclick="ConsumerInfo.toggleMembershipDetails(this); return false;">
+                <td>
+                    <a href="#" onclick="return false;">{{memberId}}</a>
+                </td>
+                <td>{{partitionCount}}</td>
+                <td>{{hostname}}</td>
+            </tr>
+            <tr class="membership-summary" style="display: none;">
+                <td colspan="3">
+                    <table class="table table-bordered table-striped table-sm">
+                        <tr>
+                            <td>Assignments</td>
+                            <td>
+                                <ul>
+                                    {{#each partitions}}
+                                    <li>
+                                        Partition {{this}}
+                                    </li>
+                                    {{/each}}
+                                </ul>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
         </script>
 
     </div>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -194,7 +194,7 @@
                         }
                     });
                     if (returnString == null) {
-                        return "Querying...";
+                        return "-unknown-";
                     }
                     return returnString;
                 },

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -233,7 +233,7 @@
                     var results = {
                         consumerDifference: 0,
                         tailDifference: 0,
-                        lagDifference: 0,
+                        lagDifference: 0
                     };
                     if (ConsumerInfo.lastOffsetData == null) {
                         return results;
@@ -247,6 +247,11 @@
                             results.consumerDifference = (newConsumerOffset - offsetData.offset);
                             results.tailDifference = (newTailOffset - offsetData.tail);
                             results.lagDifference = (newLag - oldLag);
+
+                            // If > 0, prefix with a + to indicate its increasing.
+                            if (results.lagDifference > 0) {
+                                results.lagDifference = '+' + results.lagDifference;
+                            }
 
                             return false;
                         }

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -312,8 +312,8 @@
                         var ctx = document.getElementById("ConsumerPositionsChart").getContext('2d');
                         ConsumerPositionsGraph.chart = new Chart(ctx, {
                             type: 'horizontalBar',
-                            data: ConsumerInfo.graphData,
-                            options: ConsumerInfo.graphOptions
+                            data: ConsumerPositionsGraph.graphData,
+                            options: ConsumerPositionsGraph.graphOptions
                         });
                     } else {
                         // Update the scales
@@ -362,59 +362,6 @@
                             barPercentage: 1
                         }],
                             xAxes: [{
-                            stacked: false,
-                            ticks: {
-                                beginAtZero: false
-                            }
-                        }, {
-                            display: false,
-                            stacked: false,
-                            ticks: {
-                                beginAtZero: false
-                            }
-                        }]
-                    }
-                },
-                graph: null
-            };
-
-            // Consumer Progress Graph
-            var ConsumerProgressGraph = {
-                graphData: {
-                    labels: [],
-                    datasets: [{
-                        stack: 0,
-                        label: "Tail Position",
-                        data: [],
-                        backgroundColor: 'rgba(255, 99, 132, 0.2)',
-                        borderColor: 'rgba(255,99,132,1)',
-                        borderWidth: 1
-                    }, {
-                        stack: 0,
-                        label: "Consumer Position",
-                        data: [],
-                        backgroundColor: 'rgba(54, 162, 235, 0.2)',
-                        borderColor: 'rgba(54, 162, 235, 1)',
-                        borderWidth: 1
-                    }]
-                },
-                graphOptions: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    title: {
-                        display: true,
-                        text: "Consumer Positions"
-                    },
-                    animation: {
-                        duration: 0
-                    },
-                    scales: {
-                        yAxes: [{
-                            stacked: false,
-                            categoryPercentage: 1,
-                            barPercentage: 1
-                        }],
-                        xAxes: [{
                             stacked: false,
                             ticks: {
                                 beginAtZero: false

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -201,6 +201,9 @@
 
                     // Refresh every 10 seconds
                     ConsumerInfo.refreshOffsetsTimer = setTimeout(ConsumerInfo.refreshConsumerOffsets, 10000);
+
+                    // Push update to graph
+                    ConsumerInfo.updateConsumerPositionsGraph(results.offsets);
                 },
 
                 // Attempts to map partition to its assigned consumer id.
@@ -285,7 +288,147 @@
                         jQuery('#disable-refresh-offsets-toggle').toggle(true);
                         jQuery('#enable-refresh-offsets-toggle').toggle(false);
                     }
+                },
+
+                updateConsumerPositionsGraph: function(offsets) {
+                    var labels = [];
+                    var tailPositions = [];
+                    var consumerPositions = [];
+
+                    // Process each partition
+                    jQuery.each(offsets, function(index, offsetData) {
+                        labels.push("Partition " + offsetData.partition);
+                        tailPositions.push(offsetData.tail);
+                        consumerPositions.push(offsetData.offset);
+                    });
+
+                    // Push data into graph sources
+                    ConsumerPositionsGraph.graphData.labels = labels;
+                    ConsumerPositionsGraph.graphData.datasets[0].data = tailPositions;
+                    ConsumerPositionsGraph.graphData.datasets[1].data = consumerPositions;
+
+                    // Update graph
+                    if (ConsumerPositionsGraph.graph == null) {
+                        var ctx = document.getElementById("ConsumerPositionsChart").getContext('2d');
+                        ConsumerPositionsGraph.chart = new Chart(ctx, {
+                            type: 'horizontalBar',
+                            data: ConsumerInfo.graphData,
+                            options: ConsumerInfo.graphOptions
+                        });
+                    } else {
+                        // Update the scales
+                        //ConsumerInfo.graphOptions.scales
+
+                        // Redraw
+                        ConsumerPositionsGraph.chart.update({duration: 0});
+                    }
                 }
+            };
+
+            // ConsumerPositions Graph
+            var ConsumerPositionsGraph = {
+                graphData: {
+                    labels: [],
+                        datasets: [{
+                        stack: 0,
+                        label: "Tail Position",
+                        data: [],
+                        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                        borderColor: 'rgba(255,99,132,1)',
+                        borderWidth: 1
+                    }, {
+                        stack: 0,
+                        label: "Consumer Position",
+                        data: [],
+                        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 1
+                    }]
+                },
+                graphOptions: {
+                    responsive: true,
+                        maintainAspectRatio: false,
+                        title: {
+                        display: true,
+                            text: "Consumer Positions"
+                    },
+                    animation: {
+                        duration: 0
+                    },
+                    scales: {
+                        yAxes: [{
+                            stacked: false,
+                            categoryPercentage: 1,
+                            barPercentage: 1
+                        }],
+                            xAxes: [{
+                            stacked: false,
+                            ticks: {
+                                beginAtZero: false
+                            }
+                        }, {
+                            display: false,
+                            stacked: false,
+                            ticks: {
+                                beginAtZero: false
+                            }
+                        }]
+                    }
+                },
+                graph: null
+            };
+
+            // Consumer Progress Graph
+            var ConsumerProgressGraph = {
+                graphData: {
+                    labels: [],
+                    datasets: [{
+                        stack: 0,
+                        label: "Tail Position",
+                        data: [],
+                        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                        borderColor: 'rgba(255,99,132,1)',
+                        borderWidth: 1
+                    }, {
+                        stack: 0,
+                        label: "Consumer Position",
+                        data: [],
+                        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 1
+                    }]
+                },
+                graphOptions: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    title: {
+                        display: true,
+                        text: "Consumer Positions"
+                    },
+                    animation: {
+                        duration: 0
+                    },
+                    scales: {
+                        yAxes: [{
+                            stacked: false,
+                            categoryPercentage: 1,
+                            barPercentage: 1
+                        }],
+                        xAxes: [{
+                            stacked: false,
+                            ticks: {
+                                beginAtZero: false
+                            }
+                        }, {
+                            display: false,
+                            stacked: false,
+                            ticks: {
+                                beginAtZero: false
+                            }
+                        }]
+                    }
+                },
+                graph: null
             };
 
             // On load, fire off ajax request to load results.
@@ -427,6 +570,11 @@
                     </div>
                 </div>
             </div>
+        </div>
+
+        <!-- Consumer Positions Chart -->
+        <div style="height: 500px">
+            <canvas id="ConsumerPositionsChart"></canvas>
         </div>
 
         <!-- Consumer Details Template -->

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html
+        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+        xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4"
+        xmlns:th="http://www.thymeleaf.org"
+        layout:decorate="~{layout}">
+
+<head>
+    <title>Cluster Explorer</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+
+<body>
+<section layout:fragment="content">
+    <div class="container">
+        <script type="application/javascript">
+            // Maintains state of our consumer
+            var ConsumerInfo = {
+                clusterId: '[[${cluster.id}]]',
+                consumerId: '[[${consumerId}]]',
+
+                handleConsumerDetails: function(results) {
+                    console.log(results);
+
+                    // Hide loader
+                    jQuery('#topic-loader').toggle(false);
+                }
+            };
+
+            // On load, fire off ajax request to load results.
+            jQuery(document).ready(function() {
+                // Chain initial ajax requests.
+                // Request Cluster Information
+                ApiClient.getConsumerDetails(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
+                    // handle results
+                    ConsumerInfo.handleConsumerDetails(results);
+                });
+                ApiClient.getConsumerOffsets(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
+                   console.log(results);
+                });
+            });
+        </script>
+
+    </div>
+</section>
+
+</body>
+</html>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -316,9 +316,6 @@
                             options: ConsumerPositionsGraph.graphOptions
                         });
                     } else {
-                        // Update the scales
-                        //ConsumerInfo.graphOptions.scales
-
                         // Redraw
                         ConsumerPositionsGraph.chart.update({duration: 0});
                     }
@@ -361,7 +358,7 @@
                             categoryPercentage: 1,
                             barPercentage: 1
                         }],
-                            xAxes: [{
+                        xAxes: [{
                             stacked: false,
                             ticks: {
                                 beginAtZero: false

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -298,8 +298,15 @@
                     // Process each partition
                     jQuery.each(offsets, function(index, offsetData) {
                         labels.push("Partition " + offsetData.partition);
-                        tailPositions.push(offsetData.tail);
-                        consumerPositions.push(offsetData.offset);
+                        tailPositions.push(100);
+                        if (offsetData.tail != null && offsetData.tail > 0) {
+                            var dataPoint = (offsetData.offset / offsetData.tail) * 100;
+                            consumerPositions.push(dataPoint.toPrecision(2));
+                        } else {
+                            consumerPositions.push(0);
+                        }
+                        //tailPositions.push(offsetData.tail);
+                        //consumerPositions.push(offsetData.offset);
                     });
 
                     // Push data into graph sources
@@ -344,10 +351,10 @@
                 },
                 graphOptions: {
                     responsive: true,
-                        maintainAspectRatio: false,
-                        title: {
-                        display: true,
-                            text: "Consumer Positions"
+                    maintainAspectRatio: false,
+                    title: {
+                    display: true,
+                        text: "Consumer Lag (Percent Consumed)"
                     },
                     animation: {
                         duration: 0
@@ -370,6 +377,34 @@
                                 beginAtZero: false
                             }
                         }]
+                    },
+                    tooltips: {
+                        callbacks: {
+                            label: function(toolTipItem, data) {
+                                var isTail = false;
+                                if (toolTipItem.datasetIndex == 0) {
+                                    isTail = true;
+                                }
+                                var partitionId = toolTipItem.index;
+                                var tailPosition = 0;
+                                var consumerPosition = 0;
+
+                                jQuery.each(ConsumerInfo.lastOffsetData, function(index, offsetData) {
+                                    if (offsetData.partition == partitionId) {
+                                        tailPosition = offsetData.tail;
+                                        consumerPosition = offsetData.offset;
+                                        return true;
+                                    }
+                                });
+
+                                var percentageValue = data.datasets[toolTipItem.datasetIndex].data[partitionId];
+                                if (isTail) {
+                                    return "Tail Position: " + tailPosition;
+                                } else {
+                                    return "Consumer Position: " + consumerPosition + " (" + percentageValue + "%)";
+                                }
+                            }
+                        }
                     }
                 },
                 graph: null

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readConsumer.html
@@ -26,6 +26,10 @@
                 // Holds reference to last refreshed offset data
                 lastOffsetData: [],
 
+                // Toggles for auto-refresh
+                autoRefreshOffsets: true,
+                autoRefreshConsumerDetails: true,
+
                 // Refresh ConsumerDetails
                 refreshConsumerDetails: function() {
                     // Show loaders
@@ -86,6 +90,10 @@
                     // Hide loaders
                     jQuery('#consumer-details-loader').toggle(false);
                     jQuery('#consumer-details-table').toggle(true);
+
+                    if (ConsumerInfo.autoRefreshConsumerDetails) {
+                        setTimeout(ConsumerInfo.refreshConsumerDetails, 30000);
+                    }
                 },
                 handleMembershipDetails: function(members) {
                     // Save reference.
@@ -109,8 +117,7 @@
                         });
 
                         // Sort partitions?
-                        partitions.sort(function(a, b)
-                        {
+                        partitions.sort(function(a, b) {
                             return a - b;
                         });
 
@@ -134,15 +141,13 @@
 
                 // Refresh ConsumerOffsets
                 refreshConsumerOffsets: function() {
-                    ApiClient.getConsumerOffsets(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
+                    ApiClient.getConsumerOffsetsWithTailPositions(ConsumerInfo.clusterId, ConsumerInfo.consumerId, function(results) {
                         ConsumerInfo.handleConsumerOffsets(results);
                     });
                 },
 
                 // Handle ConsumerOffsets Results
                 handleConsumerOffsets: function(results) {
-                    console.log(results);
-
                     // Get consumer offsets table
                     var table = jQuery('#consumer-offsets-tbody');
 
@@ -152,12 +157,23 @@
 
                     // Process each partition
                     jQuery.each(results.offsets, function(index, offsetData) {
+                        // Calculate differences
+                        var differences = ConsumerInfo.findOffsetDifference(
+                            offsetData.partition,
+                            offsetData.offset,
+                            offsetData.tailOffset
+                        );
+
                         // Generate html from template
                         var properties = {
                             partition: offsetData.partition,
                             memberId: ConsumerInfo.findAssignedMemberForPartition(offsetData.partition),
-                            tail: "TODO",
-                            position: offsetData.offset
+                            position: offsetData.offset,
+                            positionDiff: differences.consumerDifference,
+                            tail: offsetData.tailOffset,
+                            tailDiff: differences.tailDifference,
+                            lag: (offsetData.tailOffset - offsetData.offset),
+                            lagDiff: differences.lagDifference
                         };
                         var resultHtml = template(properties);
 
@@ -171,9 +187,17 @@
                         }
                     });
 
+                    // Retain previous
+                    ConsumerInfo.lastOffsetData = results.offsets;
+
                     // Hide loaders
                     jQuery('#consumer-offsets-loader').toggle(false);
                     jQuery('#consumer-offsets-table').toggle(true);
+
+                    if (ConsumerInfo.autoRefreshOffsets) {
+                        // Refresh every 10 seconds
+                        setTimeout(ConsumerInfo.refreshConsumerOffsets, 10000);
+                    }
                 },
 
                 // Attempts to map partition to its assigned consumer id.
@@ -181,7 +205,6 @@
                     var returnString = null;
 
                     jQuery.each(ConsumerInfo.lastMembershipDetails, function(index, member) {
-                        console.log("Looking at member")
                         jQuery.each(member.assignment, function(index, assigned) {
                             if (assigned.partition == partitionId) {
                                 returnString = member.memberId;
@@ -201,6 +224,30 @@
 
                 toggleMembershipDetails: function(el) {
                     jQuery(el).next("tr.membership-summary").toggle();
+                },
+                findOffsetDifference : function(partition, newConsumerOffset, newTailOffset) {
+                    var results = {
+                        consumerDifference: 0,
+                        tailDifference: 0,
+                        lagDifference: 0,
+                    };
+                    if (ConsumerInfo.lastOffsetData == null) {
+                        return results;
+                    }
+
+                    jQuery.each(ConsumerInfo.lastOffsetData, function(index, offsetData) {
+                        if (offsetData.partition == partition) {
+                            var newLag = newTailOffset - newConsumerOffset;
+                            var oldLag = offsetData.tailOffset - offsetData.offset;
+
+                            results.consumerDifference = (newConsumerOffset - offsetData.offset);
+                            results.tailDifference = (newTailOffset - offsetData.tailOffset);
+                            results.lagDifference = (newLag - oldLag);
+
+                            return false;
+                        }
+                    });
+                    return results;
                 }
             };
 
@@ -333,6 +380,7 @@
                                 <th>Member Id</th>
                                 <th>Tail Offset</th>
                                 <th>Consumer Offset</th>
+                                <th>Lag</th>
                             </tr>
                             </thead>
                             <tbody id="consumer-offsets-tbody">
@@ -432,8 +480,9 @@
             <tr id="partition-{{partition}}">
                 <td>{{partition}}</td>
                 <td>{{memberId}}</td>
-                <td>{{tail}}</td>
-                <td>{{position}}</td>
+                <td>{{tail}} {{#if tailDiff }} (+{{tailDiff}}) {{/if}}</td>
+                <td>{{position}} {{#if positionDiff }} (+{{positionDiff}}) {{/if}}</td>
+                <td>{{lag}} {{#if lagDiff }} ({{lagDiff}}) {{/if}}</td>
             </tr>
         </script>
 

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -269,6 +269,41 @@ public class ApiControllerTest extends AbstractMvcTest {
     }
 
     /**
+     * Test the remove Consumer end point with non admin role.
+     */
+    @Test
+    @Transactional
+    public void test_getConsumerDetails() throws Exception {
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        // Create a consumer with state on the cluster.
+        final String consumerId = createConsumerWithState(cluster);
+
+        // Construct payload
+        final String payload = "{ \"consumerId\": \"" + consumerId + "\", \"clusterId\": \"" + cluster.getId() + "\"}";
+
+        // Hit end point
+        mockMvc
+            .perform(post("/api/cluster/" + cluster.getId() + "/consumer/details")
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .content(payload)
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Validate submit button seems to show up.
+            .andExpect(content().string(containsString("true")));
+
+        // TODO finish test.
+    }
+
+    /**
      * Helper method to create a consumer with state on the given cluster.
      * @param cluster cluster to create state on.
      * @return Consumer group id created.

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -81,6 +81,8 @@ public class ApiControllerTest extends AbstractMvcTest {
     public void test_withoutAdminRole() throws Exception {
         testUrlWithOutAdminRole("/api/cluster/1/create/topic", true);
         testUrlWithOutAdminRole("/api/cluster/1/modify/topic", true);
+
+        // TODO I think this needs a post body to pass.
         testUrlWithOutAdminRole("/api/cluster/1/consumer/remove", true);
     }
 

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -28,7 +28,6 @@ import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.ClassRule;
@@ -81,8 +80,6 @@ public class ApiControllerTest extends AbstractMvcTest {
     public void test_withoutAdminRole() throws Exception {
         testUrlWithOutAdminRole("/api/cluster/1/create/topic", true);
         testUrlWithOutAdminRole("/api/cluster/1/modify/topic", true);
-
-        // TODO I think this needs a post body to pass.
         testUrlWithOutAdminRole("/api/cluster/1/consumer/remove", true);
     }
 
@@ -297,10 +294,7 @@ public class ApiControllerTest extends AbstractMvcTest {
                 .contentType(MediaType.APPLICATION_JSON)
             )
             .andDo(print())
-            .andExpect(status().is4xxClientError())
-
-            // Validate submit button seems to show up.
-            .andExpect(content().string(containsString("true")));
+            .andExpect(status().is4xxClientError());
 
         // Verify consumer still exists
         try (final AdminClient adminClient = sharedKafkaTestResource

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -25,6 +25,9 @@
 package org.sourcelab.kafka.webview.ui.controller.api;
 
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +42,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
@@ -47,6 +52,7 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -70,6 +76,7 @@ public class ApiControllerTest extends AbstractMvcTest {
     public void test_withoutAdminRole() throws Exception {
         testUrlWithOutAdminRole("/api/cluster/1/create/topic", true);
         testUrlWithOutAdminRole("/api/cluster/1/modify/topic", true);
+        testUrlWithOutAdminRole("/api/cluster/1/consumer/remove", true);
     }
 
     /**
@@ -177,5 +184,61 @@ public class ApiControllerTest extends AbstractMvcTest {
 
         assertTrue(resultJsonStr.contains(targetItem1));
         assertTrue(resultJsonStr.contains(targetItem2));
+    }
+
+    /**
+     * Test the list Consumers end point.
+     */
+    @Test
+    @Transactional
+    public void test_listConsumers() throws Exception {
+        final String consumerId = "test-consumer-id-" + System.currentTimeMillis();
+
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        // Define our new topic name
+        final String newTopic = "TestTopic-" + System.currentTimeMillis();
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(newTopic, 1, (short)1);
+
+        // Publish records into topic
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .produceRecords(10, newTopic, 0);
+
+        // Create a consumer and consume from the records, maintaining state.
+        final Properties consumerProperties = new Properties();
+        consumerProperties.put("client.id", consumerId);
+        consumerProperties.put("group.id", consumerId);
+
+        try (final KafkaConsumer consumer = sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .getKafkaConsumer(StringDeserializer.class, StringDeserializer.class, consumerProperties)) {
+
+            // Consume
+            consumer.subscribe(Collections.singleton(newTopic));
+            consumer.poll(2000L);
+
+            // Save state.
+            consumer.commitSync();
+        }
+        
+        // Hit end point
+        mockMvc
+            .perform(get("/api/cluster/" + cluster.getId() + "/consumers")
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Validate submit button seems to show up.
+            .andExpect(content().string(containsString("{\"id\":\"" + consumerId + "\",\"simple\":false}")));
     }
 }

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -203,7 +203,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Hit end point
         mockMvc
@@ -232,7 +232,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Construct payload
         final String payload = "{ \"consumerId\": \"" + consumerId + "\", \"clusterId\": \"" + cluster.getId() + "\"}";
@@ -280,7 +280,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Construct payload
         final String payload = "{ \"consumerId\": \"" + consumerId + "\", \"clusterId\": \"" + cluster.getId() + "\"}";
@@ -325,7 +325,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Hit end point
         mockMvc
@@ -338,10 +338,10 @@ public class ApiControllerTest extends AbstractMvcTest {
             .andExpect(status().isOk())
 
             // Should have content similar to:
-            // [{"consumerId":"test-consumer-id-1543825835154","partitionAssignor":"","state":"Empty","members":[],"coordinator":{"id":1,"host":"127.0.0.1","port":52168,"rack":null},"simple":false}]
+            // {"consumerId":"test-consumer-id-1543825835154","partitionAssignor":"","state":"Empty","members":[],"coordinator":{"id":1,"host":"127.0.0.1","port":52168,"rack":null},"simple":false}]
 
             // Validate submit button seems to show up.
-            .andExpect(content().string(containsString("[{\"consumerId\":\"" + consumerId )))
+            .andExpect(content().string(containsString("{\"consumerId\":\"" + consumerId )))
             .andExpect(content().string(containsString("partitionAssignor")))
             .andExpect(content().string(containsString("state")))
             .andExpect(content().string(containsString("members")))
@@ -362,7 +362,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Hit end point
         mockMvc
@@ -399,7 +399,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Hit end point
         mockMvc
@@ -434,7 +434,7 @@ public class ApiControllerTest extends AbstractMvcTest {
         );
 
         // Create a consumer with state on the cluster.
-        final String consumerId = createConsumerWithState(cluster);
+        final String consumerId = createConsumerWithState();
 
         // Hit end point
         mockMvc
@@ -458,10 +458,9 @@ public class ApiControllerTest extends AbstractMvcTest {
 
     /**
      * Helper method to create a consumer with state on the given cluster.
-     * @param cluster cluster to create state on.
      * @return Consumer group id created.
      */
-    private String createConsumerWithState(final Cluster cluster) {
+    private String createConsumerWithState() {
         final String consumerId = "test-consumer-id-" + System.currentTimeMillis();
 
         // Define our new topic name

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -350,6 +350,78 @@ public class ApiControllerTest extends AbstractMvcTest {
     }
 
     /**
+     * Test the get specific consumer end point.
+     */
+    @Test
+    @Transactional
+    public void test_specificConsumerDetails() throws Exception {
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        // Create a consumer with state on the cluster.
+        final String consumerId = createConsumerWithState(cluster);
+
+        // Hit end point
+        mockMvc
+            .perform(get("/api/cluster/" + cluster.getId() + "/consumer/" + consumerId + "/details")
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Should have content similar to:
+            // {"consumerId":"test-consumer-id-1543909384618","partitionAssignor":"","state":"Empty","members":[],"coordinator":{"id":1,"host":"127.0.0.1","port":51229,"rack":null},"simple":false}
+
+            // Validate submit button seems to show up.
+            .andExpect(content().string(containsString("{\"consumerId\":\"" + consumerId )))
+            .andExpect(content().string(containsString("partitionAssignor")))
+            .andExpect(content().string(containsString("state")))
+            .andExpect(content().string(containsString("members")))
+            .andExpect(content().string(containsString("coordinator")))
+            .andExpect(content().string(containsString("\"simple\":false")));
+    }
+
+    /**
+     * Test the get specific consumer offsets.
+     */
+    @Test
+    @Transactional
+    public void test_specificConsumerOffsets() throws Exception {
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        // Create a consumer with state on the cluster.
+        final String consumerId = createConsumerWithState(cluster);
+
+        // Hit end point
+        mockMvc
+            .perform(get("/api/cluster/" + cluster.getId() + "/consumer/" + consumerId + "/offsets")
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Should have content similar to:
+            // {"consumerId":"test-consumer-id-1543909610144","topic":"TestTopic-1543909610145","offsets":[{"partition":0,"offset":10}],"partitions":[0]}
+
+            // Validate results seem right.
+            .andExpect(content().string(containsString("\"consumerId\":\"" + consumerId )))
+            .andExpect(content().string(containsString("\"topic\":\"TestTopic-")))
+            .andExpect(content().string(containsString("\"offsets\":[{\"partition\":0,\"offset\":10}]")))
+            .andExpect(content().string(containsString("\"partitions\":[0]")));
+    }
+
+    /**
      * Helper method to create a consumer with state on the given cluster.
      * @param cluster cluster to create state on.
      * @return Consumer group id created.

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactoryTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaAdminFactoryTest.java
@@ -27,14 +27,19 @@ package org.sourcelab.kafka.webview.ui.manager.kafka;
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClusterConfig;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -66,6 +71,32 @@ public class KafkaAdminFactoryTest {
             final Collection<Node> nodes = results.nodes().get();
             assertNotNull("Should have non-null node result", nodes);
             assertFalse("Should have non-empty node", nodes.isEmpty());
+        }
+    }
+
+    /**
+     * Test that KafkaAdminFactory can create a working KafkaConsumer when connecting to a non-ssl cluster.
+     */
+    @Test
+    public void testCreateNonSslConsumer() {
+        // Create Cluster config
+        final ClusterConfig clusterConfig = ClusterConfig.newBuilder()
+            .withBrokerHosts(sharedKafkaTestResource.getKafkaConnectString())
+            .build();
+
+        // Create a topic
+        final String topicName = "MyRandomTopic";
+        sharedKafkaTestResource.getKafkaTestUtils().createTopic(topicName, 1, (short) 1);
+
+        final KafkaAdminFactory kafkaAdminFactory = new KafkaAdminFactory("NotUsed");
+
+        // Create instance
+        try (final KafkaConsumer<String, String> consumerClient = kafkaAdminFactory.createConsumer(clusterConfig, "MyClientId")) {
+
+            // Call method to validate things work as expected
+            final Map<String, List<PartitionInfo>> results = consumerClient.listTopics();
+            assertNotNull(results);
+            assertTrue(results.containsKey(topicName), "Should have our topic.");
         }
     }
 }

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactoryTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactoryTest.java
@@ -45,7 +45,7 @@ public class KafkaOperationsFactoryTest {
      * Test that KafkaAdminFactory can create a working AdminClient when connecting to a non-ssl cluster.
      */
     @Test
-    public void smokeTestNonSslOperationsClient() throws ExecutionException, InterruptedException {
+    public void smokeTestNonSslOperationsClient() {
         // Create dependencies.
         final SecretManager secretManager = new SecretManager("notused");
         final KafkaAdminFactory kafkaAdminFactory = new KafkaAdminFactory("NotUsed");

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactoryTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsFactoryTest.java
@@ -31,8 +31,6 @@ import org.sourcelab.kafka.webview.ui.manager.encryption.SecretManager;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.NodeList;
 import org.sourcelab.kafka.webview.ui.model.Cluster;
 
-import java.util.concurrent.ExecutionException;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
@@ -38,6 +38,7 @@ import org.sourcelab.kafka.webview.ui.manager.kafka.config.DeserializerConfig;
 import org.sourcelab.kafka.webview.ui.manager.kafka.config.FilterConfig;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.BrokerConfig;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConfigItem;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupDetails;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerGroupIdentifier;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.CreateTopic;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.NodeDetails;
@@ -447,6 +448,63 @@ public class KafkaOperationsTest {
 
             // Results should be sorted.
             assertEquals(consumerIds.get(0).getId(), consumerPrefix + "-" + consumerId1);
+        }
+    }
+
+    /**
+     * Test getting details about a consumer.
+     */
+    @Test
+    public void testGetConsumerDetails() {
+        // First need to create a topic.
+        final String topicName = "AnotherTestTopic-" + System.currentTimeMillis();
+
+        // Create topic
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(topicName, 1, (short) 1);
+
+        // Publish data into the topic
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .produceRecords(10, topicName, 0);
+
+        // Create cluster config.
+        final ClusterConfig clusterConfig = ClusterConfig.newBuilder()
+            .withBrokerHosts(sharedKafkaTestResource.getKafkaConnectString())
+            .build();
+        final String clientId = "BobsYerAunty";
+
+        final String consumerId1 = "ConsumerA";
+        final String consumerPrefix = "TestConsumer";
+        final String finalConsumerId = consumerPrefix + "-" + consumerId1;
+
+        consumeFromTopic(topicName, consumerId1, consumerPrefix);
+
+        // Create operations client.
+        try (final KafkaOperations operations = new KafkaOperations(kafkaAdminFactory.create(clusterConfig, clientId))) {
+            // Ask for list of consumers.
+            List<ConsumerGroupDetails> consumerIds = operations.getConsumerDetails(finalConsumerId);
+
+//            // We should have two
+//            assertEquals("Should have 2 consumers listed", consumerIds.size(), 2);
+//
+//            // Results should be sorted.
+//            assertEquals(consumerIds.get(0).getId(), consumerPrefix + "-" + consumerId1);
+//            assertEquals(consumerIds.get(1).getId(), consumerPrefix + "-" + consumerId2);
+//
+//            // Now attempt to remove consumer2
+//            final boolean result = operations.removeConsumerGroup(consumerPrefix + "-" + consumerId2);
+//            assertTrue("Should have returned true.", result);
+//
+//            // Verify only one consumer group remains
+//            consumerIds = operations.listConsumers();
+//
+//            // We should have two
+//            assertEquals("Should have 1 consumers listed", consumerIds.size(), 1);
+//
+//            // Results should be sorted.
+//            assertEquals(consumerIds.get(0).getId(), consumerPrefix + "-" + consumerId1);
         }
     }
 

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
@@ -582,7 +582,7 @@ public class KafkaOperationsTest {
 
                 // Validate bits
                 assertEquals(topicName, consumerGroupOffsets.getTopic());
-                assertEquals(finalConsumerId, consumerGroupOffsets.getConsumerGroupId());
+                assertEquals(finalConsumerId, consumerGroupOffsets.getConsumerId());
                 assertEquals(2, consumerGroupOffsets.getOffsets().size());
                 assertEquals(10, consumerGroupOffsets.getOffsetForPartition(0));
                 assertEquals(10, consumerGroupOffsets.getOffsetForPartition(1));

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/SessionIdentifierTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/SessionIdentifierTest.java
@@ -37,10 +37,11 @@ public class SessionIdentifierTest {
      */
     @Test
     public void testEquals() {
-        final SessionIdentifier id1 = new SessionIdentifier(12L, "MySession");
-        final SessionIdentifier id2 = new SessionIdentifier(12L, "MySession");
-        final SessionIdentifier id3 = new SessionIdentifier(12L, "YourSession");
-        final SessionIdentifier id4 = new SessionIdentifier(13L, "MySession");
+        final SessionIdentifier id1 = new SessionIdentifier(12L, "MySession", SessionIdentifier.Context.WEB);
+        final SessionIdentifier id2 = new SessionIdentifier(12L, "MySession", SessionIdentifier.Context.WEB);
+        final SessionIdentifier id3 = new SessionIdentifier(12L, "YourSession", SessionIdentifier.Context.WEB);
+        final SessionIdentifier id4 = new SessionIdentifier(13L, "MySession", SessionIdentifier.Context.WEB);
+        final SessionIdentifier id5 = new SessionIdentifier(13L, "MySession", SessionIdentifier.Context.STREAM);
 
         assertTrue("Should be equal", id1.equals(id1));
         assertTrue("Should be equal", id1.equals(id2));
@@ -48,6 +49,7 @@ public class SessionIdentifierTest {
         assertFalse("Should NOT be equal", id1.equals(id3));
         assertFalse("Should NOT be equal", id1.equals(id4));
         assertFalse("Should NOT be equal", id3.equals(id4));
+        assertFalse("Should NOT be equal", id4.equals(id5));
     }
 
     /**
@@ -55,8 +57,9 @@ public class SessionIdentifierTest {
      */
     @Test
     public void testGetters() {
-        final SessionIdentifier id1 = new SessionIdentifier(12L, "MySession");
+        final SessionIdentifier id1 = new SessionIdentifier(12L, "MySession", SessionIdentifier.Context.WEB);
         assertEquals(12L, id1.getUserId());
         assertEquals("MySession", id1.getSessionId());
+        assertEquals(SessionIdentifier.Context.WEB, id1.getContext());
     }
 }

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactoryTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactoryTest.java
@@ -109,7 +109,7 @@ public class WebKafkaConsumerFactoryTest {
         view.setResultsPerPartition(resultsPerPartition);
 
         // Create SessionId
-        final SessionIdentifier sessionId = new SessionIdentifier(12L, "MySession");
+        final SessionIdentifier sessionId = SessionIdentifier.newWebIdentifier(12L, "MySession");
 
         // Ok lets see what happens
         try (final WebKafkaConsumer webKafkaConsumer = factory.createWebClient(view, new ArrayList<>(), sessionId)) {
@@ -146,7 +146,7 @@ public class WebKafkaConsumerFactoryTest {
         view.setPartitions("1");
 
         // Create SessionId
-        final SessionIdentifier sessionId = new SessionIdentifier(12L, "MySession");
+        final SessionIdentifier sessionId = SessionIdentifier.newWebIdentifier(12L, "MySession");
 
         // Ok lets see what happens
         try (final WebKafkaConsumer webKafkaConsumer = factory.createWebClient(view, new ArrayList<>(), sessionId)) {
@@ -196,7 +196,7 @@ public class WebKafkaConsumerFactoryTest {
         filterDefinitions.add(filterDefinition);
 
         // Create SessionId
-        final SessionIdentifier sessionId = new SessionIdentifier(12L, "MySession");
+        final SessionIdentifier sessionId = SessionIdentifier.newWebIdentifier(12L, "MySession");
 
         // Ok lets see what happens
         try (final WebKafkaConsumer webKafkaConsumer = factory.createWebClient(view, filterDefinitions, sessionId)) {

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/ConsumerKeyTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/ConsumerKeyTest.java
@@ -64,15 +64,4 @@ public class ConsumerKeyTest {
 
         Assert.assertFalse(consumerKey1.equals(consumerKey2));
     }
-
-    @Test
-    public void testEquals_differentContexts() {
-        final long viewId = 123L;
-        final long userId = 444L;
-        final String sessionId = "BlahBlah";
-
-        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, SessionIdentifier.newWebIdentifier(userId, sessionId));
-
-        Assert.assertFalse(consumerKey1.equals(consumerKey1));
-    }
 }

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/ConsumerKeyTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/ConsumerKeyTest.java
@@ -35,8 +35,8 @@ public class ConsumerKeyTest {
         final long userId = 444L;
         final String sessionId = "BlahBlah";
 
-        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, new SessionIdentifier(userId, sessionId));
-        final WebSocketConsumersManager.ConsumerKey consumerKey2 = new WebSocketConsumersManager.ConsumerKey(viewId, new SessionIdentifier(userId, sessionId));
+        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, SessionIdentifier.newStreamIdentifier(userId, sessionId));
+        final WebSocketConsumersManager.ConsumerKey consumerKey2 = new WebSocketConsumersManager.ConsumerKey(viewId, SessionIdentifier.newStreamIdentifier(userId, sessionId));
 
         Assert.assertTrue(consumerKey1.equals(consumerKey2));
     }
@@ -47,7 +47,7 @@ public class ConsumerKeyTest {
         final long userId = 444L;
         final String sessionId = "BlahBlah";
 
-        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, new SessionIdentifier(userId, sessionId));
+        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, SessionIdentifier.newStreamIdentifier(userId, sessionId));
 
         Assert.assertTrue(consumerKey1.equals(consumerKey1));
     }
@@ -59,9 +59,20 @@ public class ConsumerKeyTest {
         final long userId = 444L;
         final String sessionId = "BlahBlah";
 
-        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId1, new SessionIdentifier(userId, sessionId));
-        final WebSocketConsumersManager.ConsumerKey consumerKey2 = new WebSocketConsumersManager.ConsumerKey(viewId2, new SessionIdentifier(userId, sessionId));
+        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId1, SessionIdentifier.newStreamIdentifier(userId, sessionId));
+        final WebSocketConsumersManager.ConsumerKey consumerKey2 = new WebSocketConsumersManager.ConsumerKey(viewId2, SessionIdentifier.newStreamIdentifier(userId, sessionId));
 
         Assert.assertFalse(consumerKey1.equals(consumerKey2));
+    }
+
+    @Test
+    public void testEquals_differentContexts() {
+        final long viewId = 123L;
+        final long userId = 444L;
+        final String sessionId = "BlahBlah";
+
+        final WebSocketConsumersManager.ConsumerKey consumerKey1 = new WebSocketConsumersManager.ConsumerKey(viewId, SessionIdentifier.newWebIdentifier(userId, sessionId));
+
+        Assert.assertFalse(consumerKey1.equals(consumerKey1));
     }
 }

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/WebSocketConsumersManagerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/socket/WebSocketConsumersManagerTest.java
@@ -99,7 +99,7 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(userId, sessionId);
+        final SessionIdentifier sessionIdentifier = SessionIdentifier.newStreamIdentifier(userId, sessionId);
 
         // Configure mocks
         when(mockConsumerFactory.createWebSocketClient(view, filters, startingPosition, sessionIdentifier))
@@ -150,7 +150,7 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(userId, sessionId);
+        final SessionIdentifier sessionIdentifier = SessionIdentifier.newStreamIdentifier(userId, sessionId);
 
         // Configure mocks
         when(mockConsumerFactory.createWebSocketClient(view, filters, StartingPosition.newHeadPosition(), sessionIdentifier))
@@ -189,7 +189,7 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier = new SessionIdentifier(userId, sessionId);
+        final SessionIdentifier sessionIdentifier = SessionIdentifier.newStreamIdentifier(userId, sessionId);
 
         final SocketKafkaConsumer mockSocketKafkaConsumer1 = mock(SocketKafkaConsumer.class);
         final SocketKafkaConsumer mockSocketKafkaConsumer2 = mock(SocketKafkaConsumer.class);
@@ -265,8 +265,8 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier1 = new SessionIdentifier(userId, sessionId1);
-        final SessionIdentifier sessionIdentifier2 = new SessionIdentifier(userId, sessionId2);
+        final SessionIdentifier sessionIdentifier1 = SessionIdentifier.newStreamIdentifier(userId, sessionId1);
+        final SessionIdentifier sessionIdentifier2 = SessionIdentifier.newStreamIdentifier(userId, sessionId2);
 
         final SocketKafkaConsumer mockSocketKafkaConsumer1 = mock(SocketKafkaConsumer.class);
         final SocketKafkaConsumer mockSocketKafkaConsumer2 = mock(SocketKafkaConsumer.class);
@@ -341,8 +341,8 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier1 = new SessionIdentifier(userId, sessionId1);
-        final SessionIdentifier sessionIdentifier2 = new SessionIdentifier(userId, sessionId2);
+        final SessionIdentifier sessionIdentifier1 = SessionIdentifier.newStreamIdentifier(userId, sessionId1);
+        final SessionIdentifier sessionIdentifier2 = SessionIdentifier.newStreamIdentifier(userId, sessionId2);
 
         final SocketKafkaConsumer mockSocketKafkaConsumer1 = mock(SocketKafkaConsumer.class);
         final SocketKafkaConsumer mockSocketKafkaConsumer2 = mock(SocketKafkaConsumer.class);
@@ -392,8 +392,8 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier1 = new SessionIdentifier(userId, sessionId1);
-        final SessionIdentifier sessionIdentifier2 = new SessionIdentifier(userId, sessionId2);
+        final SessionIdentifier sessionIdentifier1 = SessionIdentifier.newStreamIdentifier(userId, sessionId1);
+        final SessionIdentifier sessionIdentifier2 = SessionIdentifier.newStreamIdentifier(userId, sessionId2);
 
         final SocketKafkaConsumer mockSocketKafkaConsumer1 = mock(SocketKafkaConsumer.class);
         final SocketKafkaConsumer mockSocketKafkaConsumer2 = mock(SocketKafkaConsumer.class);
@@ -448,8 +448,8 @@ public class WebSocketConsumersManagerTest {
 
         final Collection<FilterDefinition> filters = new ArrayList<>();
         final StartingPosition startingPosition = StartingPosition.newHeadPosition();
-        final SessionIdentifier sessionIdentifier1 = new SessionIdentifier(userId, sessionId1);
-        final SessionIdentifier sessionIdentifier2 = new SessionIdentifier(userId, sessionId2);
+        final SessionIdentifier sessionIdentifier1 = SessionIdentifier.newStreamIdentifier(userId, sessionId1);
+        final SessionIdentifier sessionIdentifier2 = SessionIdentifier.newStreamIdentifier(userId, sessionId2);
 
         final SocketKafkaConsumer mockSocketKafkaConsumer1 = mock(SocketKafkaConsumer.class);
         final SocketKafkaConsumer mockSocketKafkaConsumer2 = mock(SocketKafkaConsumer.class);

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
 
     <!-- Define submodules -->
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <!-- Define submodules -->
     <modules>


### PR DESCRIPTION
This PR adds the ability to view/delete consumer groups stored within a Kafka cluster, as well as monitor their positions within a topic.