### PR TITLE
ISSUE-111 - More gracefully handle protobuf serialization

### DIFF
--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -171,6 +171,18 @@
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
         </dependency>
+        <!-- Explicitly include updated protocol buffer version -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>com.fasterxml.jackson.core</groupId>-->
+            <!--<artifactId>jackson-annotations</artifactId>-->
+            <!--<version>2.9.7</version>-->
+        <!--</dependency>-->
+
 
         <!-- For tests -->
         <dependency>
@@ -214,14 +226,6 @@
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <version>1.1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Test case for validating protocol buffer support in Jackson -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -177,12 +177,6 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.6.1</version>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>com.fasterxml.jackson.core</groupId>-->
-            <!--<artifactId>jackson-annotations</artifactId>-->
-            <!--<version>2.9.7</version>-->
-        <!--</dependency>-->
-
 
         <!-- For tests -->
         <dependency>

--- a/kafka-webview-ui/src/main/frontend/gulp-tasks/build-dist.js
+++ b/kafka-webview-ui/src/main/frontend/gulp-tasks/build-dist.js
@@ -40,6 +40,7 @@ var vendorsJS = [
   'node_modules/pace-progress/pace.min.js',
   'node_modules/popper.js/dist/umd/popper.min.js',
   'node_modules/popper.js/dist/umd/popper.min.js.map',
+  'node_modules/renderjson/renderjson.js',
   'node_modules/select2/dist/js/select2.min.js',
   'node_modules/toastr/toastr.js',
   'node_modules/handlebars/dist/handlebars.js',

--- a/kafka-webview-ui/src/main/frontend/package-lock.json
+++ b/kafka-webview-ui/src/main/frontend/package-lock.json
@@ -6386,6 +6386,11 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
+    "renderjson": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/renderjson/-/renderjson-1.4.0.tgz",
+      "integrity": "sha512-R0IZoxjWQP4XMJjLkPjNKSwjDyl20EiLohyu1Os7AvIvO4F4Vtar1N6IjJLPLjDN7OYOXTsqtIVJupQnQMvYQw=="
+    },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",

--- a/kafka-webview-ui/src/main/frontend/package.json
+++ b/kafka-webview-ui/src/main/frontend/package.json
@@ -14,6 +14,7 @@
     "multiselect-two-sides": "^2.4.0",
     "pace-progress": "^1.0.2",
     "popper.js": "^1.12.5",
+    "renderjson": "^1.4.0",
     "simple-line-icons": "^2.4.1",
     "sockjs-client": "^1.3.0",
     "stompjs": "^2.3.3"

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/PluginConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/PluginConfig.java
@@ -24,6 +24,7 @@
 
 package org.sourcelab.kafka.webview.ui.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.sourcelab.kafka.webview.ui.manager.encryption.SecretManager;
@@ -36,6 +37,7 @@ import org.sourcelab.kafka.webview.ui.manager.plugin.PluginFactory;
 import org.sourcelab.kafka.webview.ui.manager.plugin.UploadManager;
 import org.sourcelab.kafka.webview.ui.manager.sasl.SaslUtility;
 import org.sourcelab.kafka.webview.ui.plugin.filter.RecordFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -122,11 +124,16 @@ public class PluginConfig {
      * @return Jackson2ObjectMapperBuilderCustomizer instance.
      */
     @Bean
-    public Jackson2ObjectMapperBuilderCustomizer addCustomBigDecimalDeserialization() {
+    public Jackson2ObjectMapperBuilderCustomizer registerJacksonProtobufModule() {
         return jacksonObjectMapperBuilder -> {
-            // Register custom protocol buffer serializer as protocol buffers is a common serialization format.
+            // Register custom protocol buffer serializer.
             jacksonObjectMapperBuilder.modulesToInstall(new ProtobufModule());
         };
+    }
+
+    @Autowired(required = true)
+    public void configureJackson(ObjectMapper jackson2ObjectMapper) {
+        jackson2ObjectMapper.registerModule(new ProtobufModule());
     }
     
     /**

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/WebConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/WebConfig.java
@@ -24,10 +24,17 @@
 
 package org.sourcelab.kafka.webview.ui.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import java.util.List;
 
 /**
  * Application configuration for Web resources.
@@ -57,4 +64,20 @@ public class WebConfig extends WebMvcConfigurerAdapter {
             .addResourceHandler("/img/**")
             .addResourceLocations("classpath:/static/img/");
     }
+
+    /**
+     * Ensure that ProtobufModule is registered so protobufs can easily be serialized.
+     * @param converters list of converters registered.
+     */
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.clear();
+
+        final ObjectMapper mapper = Jackson2ObjectMapperBuilder
+            .json()
+            .modulesToInstall(new ProtobufModule())
+            .build();
+        converters.add(new MappingJackson2HttpMessageConverter(mapper));
+    }
+
 }

--- a/kafka-webview-ui/src/main/resources/templates/layout.html
+++ b/kafka-webview-ui/src/main/resources/templates/layout.html
@@ -53,6 +53,9 @@
     <script src="/vendors/js/jquery-ui.min.js"></script>
     <script src="/vendors/js/jquery-ui-timepicker-addon.min.js"></script>
 
+    <!-- JSON Rendering -->
+    <script src="/vendors/js/renderjson.min.js"></script>
+
     <!-- Websocket -->
     <script src="/vendors/js/sockjs.min.js"></script>
     <script src="/vendors/js/stomp.min.js"></script>

--- a/kafka-webview-ui/src/main/resources/templates/stream/index.html
+++ b/kafka-webview-ui/src/main/resources/templates/stream/index.html
@@ -109,6 +109,10 @@
             // End point to consume a view
             consumerBaseUrl: "/user/topic/view",
 
+            // JSON Render settings.
+            useJsonRender: true,
+            jsonRenderToLevel: 1000,
+
             getConsumerUrl : function() {
                 return SocketDetails.consumerBaseUrl + '/' + SocketDetails.viewId + '/' + SocketDetails.userId;
             },
@@ -245,12 +249,44 @@
 
             // Append results to browser
             appendResult: function(result) {
+                // Determine how to render key
+                var keyIsJson = false;
+                var key = result.key;
+
+                // Determine if result.value is a string, or JSON object
+                if (result.key instanceof Object && !(result.key instanceof String)) {
+                    // Use fancy json rendering.
+                    if (SocketDetails.useJsonRender) {
+                        keyIsJson = true;
+                    } else {
+                        // Convert to String
+                        key = JSON.stringify(result.key);
+                    }
+                }
+
+                // Determine how to render value
+                var valueIsJson = false;
+                var value = result.value;
+
+                // Determine if result.value is a string, or JSON object
+                if (result.value instanceof Object && !(result.value instanceof String)) {
+                    // Use fancy json rendering.
+                    if (SocketDetails.useJsonRender) {
+                        valueIsJson = true;
+                    } else {
+                        // Convert to String
+                        value = JSON.stringify(result.value);
+                    }
+                }
+
                 // Generate html from template
                 var properties = {
                     partition: result.partition,
                     offset: result.offset,
-                    key: result.key,
-                    value: result.value,
+                    key: key,
+                    keyIsJson: keyIsJson,
+                    value: value,
+                    valueIsJson: valueIsJson,
                     timestamp: result.timestamp,
                     date: DateTools.displayTimestamp(result.timestamp),
                     timezone: DateTools.localTimezone,
@@ -260,6 +296,14 @@
 
                 // Prepend it to the top of our table
                 SocketDetails.resultsTable.prepend(resultHtml);
+
+                // If json, generate formatted json
+                if (keyIsJson) {
+                    jQuery("td#key-" + result.partition + "-" + result.offset).html(renderjson(result.key));
+                }
+                if (valueIsJson) {
+                    jQuery("td#value-" + result.partition + "-" + result.offset).html(renderjson(result.value));
+                }
 
                 // Remove rows > max results from the end
                 var resultRows = SocketDetails.resultsTable.children();
@@ -294,6 +338,8 @@
              * for the selected value.
              */
             jQuery('#startPositionSelector').change(function(event) {
+                renderjson.set_show_to_level(SocketDetails.jsonRenderToLevel);
+
                 var selected = jQuery(this).val();
 
                 // Hide all options
@@ -320,8 +366,12 @@
                 <span class="timestamp" title="{{date}}">{{timestamp}}</span>
                 {{/if}}
             </td>
-            <td><pre>{{key}}</pre></td>
-            <td><pre>{{value}}</pre></td>
+            <td id="key-{{partition}}-{{offset}}">
+                {{#unless keyIsJson }}<pre>{{key}}</pre>{{/unless}}
+            </td>
+            <td id="value-{{partition}}-{{offset}}">
+                {{#unless valueIsJson }}<pre>{{value}}</pre>{{/unless}}
+            </td>
         </tr>
     </script>
 </section>

--- a/kafka-webview-ui/src/main/resources/templates/view/consume.html
+++ b/kafka-webview-ui/src/main/resources/templates/view/consume.html
@@ -23,10 +23,16 @@
                 viewId: '[[${view.id}]]',
                 formatDates: true,
                 resultsPerPartition: '[[${view.resultsPerPartition}]]',
+
+                // JSON Render settings.
+                useJsonRender: true,
+                jsonRenderToLevel: 1000
             };
 
             // On load, fire off ajax request to load results.
             jQuery(document).ready(function() {
+                renderjson.set_show_to_level(ConsumerInfo.jsonRenderToLevel);
+
                 // Fire off initial consume request
                 executeConsume('next');
 
@@ -160,12 +166,44 @@
 
                 // Loop over results
                 jQuery.each(results.results, function (index, result) {
+                    // Determine how to render key
+                    var keyIsJson = false;
+                    var key = result.key;
+
+                    // Determine if result.value is a string, or JSON object
+                    if (result.key instanceof Object && !(result.key instanceof String)) {
+                        // Use fancy json rendering.
+                        if (ConsumerInfo.useJsonRender) {
+                            keyIsJson = true;
+                        } else {
+                            // Convert to String
+                            key = JSON.stringify(result.key);
+                        }
+                    }
+
+                    // Determine how to render value
+                    var valueIsJson = false;
+                    var value = result.value;
+
+                    // Determine if result.value is a string, or JSON object
+                    if (result.value instanceof Object && !(result.value instanceof String)) {
+                        // Use fancy json rendering.
+                        if (ConsumerInfo.useJsonRender) {
+                            valueIsJson = true;
+                        } else {
+                            // Convert to String
+                            value = JSON.stringify(result.value);
+                        }
+                    }
+
                     // Generate html from template
                     var properties = {
                         partition: result.partition,
                         offset: result.offset,
-                        key: result.key,
-                        value: result.value,
+                        key: key,
+                        keyIsJson: keyIsJson,
+                        value: value,
+                        valueIsJson: valueIsJson,
                         timestamp: result.timestamp,
                         date: DateTools.displayTimestamp(result.timestamp),
                         timezone: DateTools.localTimezone,
@@ -175,6 +213,14 @@
 
                     // Append it to our table
                     jQuery(table).append(resultHtml);
+
+                    // If json, generate formatted json
+                    if (keyIsJson) {
+                        jQuery("td#key-" + result.partition + "-" + result.offset).html(renderjson(result.key));
+                    }
+                    if (valueIsJson) {
+                        jQuery("td#value-" + result.partition + "-" + result.offset).html(renderjson(result.value));
+                    }
                 });
 
                 // Hide loader
@@ -393,8 +439,12 @@
                     <span class="timestamp" title="{{date}}">{{timestamp}}</span>
                     {{/if}}
                 </td>
-                <td><pre>{{key}}</pre></td>
-                <td><pre>{{value}}</pre></td>
+                <td id="key-{{partition}}-{{offset}}">
+                    {{#unless keyIsJson }}<pre>{{key}}</pre>{{/unless}}
+                </td>
+                <td id="value-{{partition}}-{{offset}}">
+                    {{#unless isJson }}<pre>{{value}}</pre>{{/unless}}
+                </td>
             </tr>
         </script>
     </div>


### PR DESCRIPTION
Protocol Buffer objects are not out of the box compatible with how Kafka-Webview serializes data across it's API requests.

This change registers a 3rd party jackson serializer to prevent errors.  It also now supports converting JSON rendered objects using the renderJson library.

It's still recommended to have your deserializers return Strings if you need any special formatting.

for #111 