### PR TITLE
No longer require keystore or keystore password for SASL+SSL clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.1 (UNRELEASED)
+#### Bug fixes
+- [ISSUE-116](https://github.com/SourceLabOrg/kafka-webview/issues/116) No longer require KeyStore and KeyStore password when configuring a SSL+SASL cluster.
+
 ## 2.1.0 (12/20/2018)
 #### New Features
 - Add support for SASL authentication to Kafka clusters.

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/dev-cluster/startDevCluster.sh
+++ b/dev-cluster/startDevCluster.sh
@@ -14,7 +14,7 @@ cd "${0%/*}"
 if [ ! -f $KEY_STORE_FILE ] || [ ! -f $TRUST_STORE_FILE ]; then
     echo "Key store files do no exist...generating now...";
     ## Build certificates
-    ././../generateDummySslCertificates.sh
+    ./../../generateDummySslCertificates.sh
 fi
 
 ## If jar doesn't exit, build it.

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaClientConfigUtil.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaClientConfigUtil.java
@@ -121,9 +121,11 @@ public class KafkaClientConfigUtil {
             config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name);
         } else {
             config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name);
+
+            // KeyStore and KeyStore password only needed if NOT using SASL
+            config.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStoreRootPath + "/" + clusterConfig.getKeyStoreFile());
+            config.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clusterConfig.getKeyStorePassword());
         }
-        config.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStoreRootPath + "/" + clusterConfig.getKeyStoreFile());
-        config.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clusterConfig.getKeyStorePassword());
         config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, keyStoreRootPath + "/" + clusterConfig.getTrustStoreFile());
         config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, clusterConfig.getTrustStorePassword());
     }
@@ -143,6 +145,10 @@ public class KafkaClientConfigUtil {
         if (clusterConfig.isUseSsl()) {
             // SASL+SSL
             config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name);
+
+            // Keystore and keystore password not required if using SASL+SSL
+            config.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            config.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
         } else {
             // Just SASL PLAINTEXT
             config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_PLAINTEXT.name);

--- a/kafka-webview-ui/src/main/resources/templates/configuration/cluster/create.html
+++ b/kafka-webview-ui/src/main/resources/templates/configuration/cluster/create.html
@@ -16,10 +16,21 @@
             jQuery('#ssl').click(function() {
                 var isChecked = jQuery('#ssl').is(':checked');
                 jQuery('#ssl-options').toggle(isChecked);
+
+                // If SASL is enabled, we hide SSL Keystore options
+                // If SASL is disabled, we show SSL Keystore options.
+                var isSaslChecked = jQuery('#sasl').is(':checked');
+                jQuery('#ssl-keystore-options').toggle(!isSaslChecked);
             });
             jQuery('#sasl').click(function() {
                 var isChecked = jQuery('#sasl').is(':checked');
+
+                // Toggle SASL Options on/off
                 jQuery('#sasl-options').toggle(isChecked);
+
+                // If SASL is enabled, we hide SSL Keystore options
+                // If SASL is disabled, we show SSL Keystore options.
+                jQuery('#ssl-keystore-options').toggle(!isChecked);
             });
             jQuery('#saslMechanism').change(function() {
                 var selected = jQuery(this).val();
@@ -138,36 +149,38 @@
                                 </div>
 
                                 <!-- Client KeyStore file -->
-                                <div class="form-group row">
-                                    <label class="col-md-3 form-control-label" for="keyStoreFile">
-                                        Key Store JKS
-                                        <div
-                                            th:if="${clusterForm.getKeyStoreFilename()} != null"
-                                            th:text="'Current: ' + ${clusterForm.getKeyStoreFilename()}">
+                                <div id="ssl-keystore-options" th:styleappend="${clusterForm.getSsl() && !clusterForm.getSasl()} ? 'display: block;' : 'display: none;'">
+                                    <div class="form-group row">
+                                        <label class="col-md-3 form-control-label" for="keyStoreFile">
+                                            Key Store JKS
+                                            <div
+                                                th:if="${clusterForm.getKeyStoreFilename()} != null"
+                                                th:text="'Current: ' + ${clusterForm.getKeyStoreFilename()}">
+                                            </div>
+                                        </label>
+                                        <div class="col-md-9">
+                                            <input
+                                                id="keyStoreFile" name="keyStoreFile" class="form-control" type="file"
+                                                placeholder="Select KeyStore JKS"
+                                                th:errorclass="is-invalid"
+                                                th:value="*{keyStoreFile}">
+                                            <div class="invalid-feedback" th:if="${#fields.hasErrors('keyStoreFile')}" th:errors="*{keyStoreFile}"/>
                                         </div>
-                                    </label>
-                                    <div class="col-md-9">
-                                        <input
-                                            id="keyStoreFile" name="keyStoreFile" class="form-control" type="file"
-                                            placeholder="Select KeyStore JKS"
-                                            th:errorclass="is-invalid"
-                                            th:value="*{keyStoreFile}">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('keyStoreFile')}" th:errors="*{keyStoreFile}"/>
                                     </div>
-                                </div>
 
-                                <!-- Client KeyStore Password -->
-                                <div class="form-group row">
-                                    <label class="col-md-3 form-control-label" for="keyStorePassword">
-                                        Key Store Password
-                                    </label>
-                                    <div class="col-md-9">
-                                        <input
-                                            id="keyStorePassword" name="keyStorePassword" class="form-control" type="password"
-                                            placeholder="Key Store password"
-                                            th:errorclass="is-invalid"
-                                            th:value="*{keyStorePassword}">
-                                        <div class="invalid-feedback" th:if="${#fields.hasErrors('keyStorePassword')}" th:errors="*{keyStorePassword}"/>
+                                    <!-- Client KeyStore Password -->
+                                    <div class="form-group row">
+                                        <label class="col-md-3 form-control-label" for="keyStorePassword">
+                                            Key Store Password
+                                        </label>
+                                        <div class="col-md-9">
+                                            <input
+                                                id="keyStorePassword" name="keyStorePassword" class="form-control" type="password"
+                                                placeholder="Key Store password"
+                                                th:errorclass="is-invalid"
+                                                th:value="*{keyStorePassword}">
+                                            <div class="invalid-feedback" th:if="${#fields.hasErrors('keyStorePassword')}" th:errors="*{keyStorePassword}"/>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaClientConfigUtilTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaClientConfigUtilTest.java
@@ -99,7 +99,7 @@ public class KafkaClientConfigUtilTest {
 
         // Validate
         validateDefaultKeys(config);
-        validateSsl(config, "SSL");
+        validateSsl(config, "SSL", true);
         validateNoSasl(config);
     }
 
@@ -170,17 +170,27 @@ public class KafkaClientConfigUtilTest {
 
         // Validate
         validateDefaultKeys(config);
-        validateSsl(config, "SASL_SSL");
+        validateSsl(config, "SASL_SSL", false);
         validateSaslPlainMechanism(config, "SASL_SSL");
     }
 
-    private void validateSsl(final Map<String, Object> config, final String expectedSecurityProtocol) {
+    private void validateSsl(
+        final Map<String, Object> config,
+        final String expectedSecurityProtocol,
+        final boolean shouldHaveKeyStoreConfiguration
+    ) {
         assertNotNull(config);
         validateKey(config, CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, expectedSecurityProtocol);
-        validateKey(config, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/tmp/" + expectedKeyStoreFile);
-        validateKey(config, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, expectedKeyStorePassword);
         validateKey(config, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/tmp/" + expectedTrustStoreFile);
         validateKey(config, SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, expectedTrustStorePassword);
+
+        if (shouldHaveKeyStoreConfiguration) {
+            validateKey(config, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/tmp/" + expectedKeyStoreFile);
+            validateKey(config, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, expectedKeyStorePassword);
+        } else {
+            validateNoKey(config, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            validateNoKey(config, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+        }
     }
 
     private void validateNoSsl(final Map<String, Object> config) {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <!-- Define submodules -->
     <modules>


### PR DESCRIPTION
Fixes issue #116 

**Issue**
Currently creating a connection to a SASL+SSL cluster requires providing a KEYSTORE and KEYSTORE PASSWORD.  These are not required for connecting to a SASL+SSL cluster.  Only the TRUSTSTORE and TRUSTSTORE PASSWORD.

**Suggested Fix**
No longer require these fields when creating or updating a cluster connection in this scenario.