### PR TITLE
[ISSUE-142] Add ability to search brokers, configs, topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 (UNRELEASED)
+
+#### New Features
+- Ability to remove topics from a cluster.
+- Ability to search topics within a cluster.
+
 ## 2.1.3 (01/19/2019)
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.2.0 (UNRELEASED)
 
 #### New Features
-- Ability to search topics within a cluster.
+- Ability to search various datatables within the Cluster section of the application.
 
 ## 2.1.4 (02/19/2019)
 - [ISSUE-136](https://github.com/SourceLabOrg/kafka-webview/issues/136) Fix URLs when running Kafka-Webview behind a reverse proxy with a URL prefix.  You can configure Kafka WebView by setting the following configuration option in your config.yml file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.2.0 (UNRELEASED)
 
 #### New Features
-- Ability to remove topics from a cluster.
 - Ability to search topics within a cluster.
 
 ## 2.1.4 (02/19/2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ server:
   servlet:
     context-path: /prefix/here
 ```
->>>>>>> 09b13e34f4aa14c65afb9d5fcd207b560e8e1a23
 
 ## 2.1.3 (01/19/2019)
 

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.1.3</version>
+        <version>2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.1.3</version>
+        <version>2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.1.3</version>
+        <version>2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -482,6 +482,11 @@ var SearchTools = {
             return true;
         }
 
+        // If content is null, cannot match.
+        if (content === null) {
+            return false;
+        }
+
         // Otherwise check to see if it matches
         if (content.toLowerCase().indexOf(searchStr.toLowerCase()) === -1) {
             // Doesn't match

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -471,3 +471,23 @@ var DateTools = {
         return timezone_standard;
     }
 };
+
+/**
+ * Common Search Tooling.
+ */
+var SearchTools = {
+    doesMatchText : function(searchStr, content) {
+        // If empty search String, assume match all.
+        if (searchStr === null || searchStr.length === 0) {
+            return true;
+        }
+
+        // Otherwise check to see if it matches
+        if (content.toLowerCase().indexOf(searchStr.toLowerCase()) === -1) {
+            // Doesn't match
+            return false;
+        }
+        // Matches
+        return true;
+    }
+};

--- a/kafka-webview-ui/src/main/frontend/js/app.js
+++ b/kafka-webview-ui/src/main/frontend/js/app.js
@@ -316,6 +316,23 @@ var ApiClient = {
             }
         });
     },
+    removeTopic: function(clusterId, name, callback) {
+        var payload = JSON.stringify({
+            name: name
+        });
+        jQuery.ajax({
+            type: 'POST',
+            url: '/api/cluster/' + clusterId + '/delete/topic',
+            data: payload,
+            dataType: 'json',
+            headers: ApiClient.getCsrfHeader(),
+            success: callback,
+            error: ApiClient.defaultErrorHandler,
+            beforeSend: function(xhr) {
+                xhr.setRequestHeader('Content-type', 'application/json; charset=utf-8');
+            }
+        });
+    },
     modifyTopicConfig: function(clusterId, topic, configName, configValue, callback) {
         var payloadJson = {
             topic: topic,

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/SecurityConfig.java
@@ -196,6 +196,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // Modify topic
                 "/api/cluster/*/modify/**",
 
+                // Delete topic
+                "/api/cluster/*/delete/**",
+
                 // Remove consumer group
                 "/api/cluster/*/consumer/remove"
 

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/ApiController.java
@@ -400,9 +400,11 @@ public class ApiController extends BaseController {
     /**
      * POST Delete existing topic on cluster.
      * This should require ADMIN role.
+     *
+     * @TODO explicitly disabled until custom user roles. https://github.com/SourceLabOrg/kafka-webview/issues/157
      */
-    @ResponseBody
-    @RequestMapping(path = "/cluster/{id}/delete/topic", method = RequestMethod.POST, produces = "application/json")
+//    @ResponseBody
+//    @RequestMapping(path = "/cluster/{id}/delete/topic", method = RequestMethod.POST, produces = "application/json")
     public ResultResponse deleteTopic(@PathVariable final Long id, @RequestBody final DeleteTopicRequest deleteTopicRequest) {
         // Retrieve cluster
         final Cluster cluster = retrieveClusterById(id);

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/DeleteTopicRequest.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/controller/api/requests/DeleteTopicRequest.java
@@ -1,0 +1,47 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018, 2019 SourceLab.org (https://github.com/SourceLabOrg/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.sourcelab.kafka.webview.ui.controller.api.requests;
+
+/**
+ * Represents a request to remove an existing topic from kafka cluster.
+ */
+public class DeleteTopicRequest {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "DeleteTopicRequest{"
+            + "name='" + name + '\''
+            + '}';
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperations.java
@@ -30,6 +30,8 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsOptions;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
@@ -285,6 +287,26 @@ public class KafkaOperations implements AutoCloseable {
 
             // Lets return updated topic details
             return getTopicConfig(topic);
+        } catch (final InterruptedException | ExecutionException exception) {
+            // TODO Handle this
+            throw new RuntimeException(exception.getMessage(), exception);
+        }
+    }
+
+    /**
+     * Remove a topic from a kafka cluster.  This is destructive!
+     * @param topic name of the topic to remove.
+     * @return true on success.
+     */
+    public boolean removeTopic(final String topic) {
+        try {
+            final DeleteTopicsResult result = adminClient.deleteTopics(Collections.singletonList(topic));
+
+            // Wait for the async request to process.
+            result.all().get();
+
+            // return true?
+            return true;
         } catch (final InterruptedException | ExecutionException exception) {
             // TODO Handle this
             throw new RuntimeException(exception.getMessage(), exception);

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicList.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicList.java
@@ -64,6 +64,28 @@ public class TopicList {
         return Collections.unmodifiableList(topicNames);
     }
 
+    /**
+     * Given a search value for topic names, return all entries that match search.
+     * @param search search string.
+     * @return filtered TopicList.
+     */
+    public TopicList filterByTopicName(final String search) {
+        // Null means match nothing.
+        if (search == null) {
+            return new TopicList(Collections.emptyList());
+        }
+        final String normalizedSearch = search.toLowerCase();
+
+        final List<TopicListing> topicListings = new ArrayList<>();
+        for (final TopicListing topicListing : getTopics()) {
+            if (topicListing.getName().toLowerCase().contains(normalizedSearch)) {
+                topicListings.add(topicListing);
+            }
+        }
+
+        return new TopicList(topicListings);
+    }
+
     @Override
     public String toString() {
         return "TopicList{"

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -17,7 +17,12 @@
             // Maintains state of our consumer
             var ClusterInfo = {
                 clusterId: '[[${cluster.id}]]',
+
+                // Cached copy of topics for client side searching
                 cachedTopics: [],
+
+                // Cached copy of consumers for client side searching
+                cachedConsumers: [],
 
                 // Handle cluster node results ajax result
                 handleClusterNodeResults: function(results) {
@@ -77,10 +82,9 @@
 
                     jQuery.each(ClusterInfo.cachedTopics, function(index, result) {
                         // Filter
-                        if (searchStr != null && searchStr.length > 0) {
-                            if (result.name.toLowerCase().indexOf(searchStr.toLowerCase()) === -1) {
-                                return;
-                            }
+                        if (!SearchTools.doesMatchText(searchStr, result.name)) {
+                            // Skip
+                            return;
                         }
                         matchedEntries++;
 
@@ -112,8 +116,17 @@
                 },
 
                 // Handle all consumers results ajax result
-                handleConsumers: function(results) {
-                    // Clear topics table
+                handleAllConsumers: function(results) {
+                    ClusterInfo.cachedConsumers = results;
+                    ClusterInfo.displayConsumers();
+                },
+
+                displayConsumers: function() {
+                    // Get our search text
+                    var searchStr = jQuery("#consumerSearch").val();
+                    var matchedEntries = 0;
+
+                    // Clear consumers table
                     var table = jQuery('#consumers-tbody');
                     jQuery(table).empty();
 
@@ -121,7 +134,14 @@
                     var source   = jQuery('#consumers-template').html();
                     var template = Handlebars.compile(source);
 
-                    jQuery.each(results, function(index, result) {
+                    jQuery.each(ClusterInfo.cachedConsumers, function(index, result) {
+                        // Filter
+                        if (!SearchTools.doesMatchText(searchStr, result.consumerId)) {
+                            // Skip
+                            return;
+                        }
+                        matchedEntries++;
+
                         // Collect unique topics
                         var topics = [];
                         jQuery.each(result.members, function(index, member) {
@@ -153,7 +173,7 @@
                     // Hide loader
                     jQuery('#consumers-loader').toggle(false);
 
-                    if (results.length == 0) {
+                    if (matchedEntries === 0) {
                         jQuery('#consumers-no-results').toggle(true);
                         jQuery('#consumers-table').toggle(false);
                     } else {
@@ -173,7 +193,7 @@
                     // Fire off request to get consumer details
                     ApiClient.getAllConsumersWithDetails(ClusterInfo.clusterId, function(results) {
                         // Handle results
-                        ClusterInfo.handleConsumers(results);
+                        ClusterInfo.handleAllConsumers(results);
                     });
                 },
                 removeConsumer: function(consumerId) {
@@ -378,6 +398,16 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Cluster <strong th:text="${cluster.name}"></strong> Consumer Groups
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="consumerSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="ClusterInfo.displayConsumers();">
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -360,7 +360,7 @@
                                 <th>Topic</th>
                                 <th>Partitions</th>
                                 <th>Status</th>
-                                <th sec:authorize="hasRole('ROLE_ADMIN')" class="text-right">Action</th>
+                                <!--<th sec:authorize="hasRole('ROLE_ADMIN')" class="text-right">Action</th>-->
                             </tr>
                             </thead>
                             <tbody id="topics-tbody">
@@ -452,7 +452,7 @@
                         <span class="badge badge-info">Internal topic</span>
                     {{/if}}
                 </td>
-                <td class="text-right" sec:authorize="hasRole('ROLE_ADMIN')">
+                <td class="text-right" th:if="${false}" sec:authorize="hasRole('ROLE_ADMIN')">
                     <div class="dropdown">
                         <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fa fa-gear"></i>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -602,7 +602,7 @@
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-secondary" type="button" data-dismiss="modal">Close</button>
-                        <button class="btn btn-primary" type="button" onclick="ClusterInfo.confirmedRemoveTopic();">Remove topic</button>
+                        <button class="btn btn-warning" type="button" onclick="ClusterInfo.confirmedRemoveTopic();">Remove topic</button>
                     </div>
                 </div>
             </div>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -198,12 +198,32 @@
                     )
                 },
                 removeTopic : function(topicName) {
-                    if (!confirm('Are you sure you want to remove this topic? This is destructive and can NOT be un-done!')) {
-                        return;
+                    // Show modal
+                    jQuery("#removeTopicConfirm").text(topicName);
+                    jQuery('#deleteTopicModal').modal('show');
+                },
+                confirmedRemoveTopic : function() {
+                    // Validate form.
+                    var expectedTopic = jQuery("#removeTopicConfirm").text();
+                    var confirmedTopic = jQuery("#removeTopicConfirmed").val();
+
+                    console.log(expectedTopic + " === " + confirmedTopic);
+
+                    if (expectedTopic !== confirmedTopic) {
+                        alert("Enter the topic you want to remove.")
+                        return false;
                     }
+
+                    // Hide modal
+                    jQuery('#deleteTopicModal').modal('hide');
+
+                    // Reset form
+                    jQuery('#removeTopicConfirmed').val("");
+                    jQuery("#removeTopicConfirm").text("");
+
                     ApiClient.removeTopic(
                         ClusterInfo.clusterId,
-                        topicName,
+                        expectedTopic,
                         function(resultMsg) {
                             UITools.showSuccess('Successfully removed topic.');
                             ClusterInfo.loadTopics();
@@ -512,6 +532,49 @@
                     <div class="modal-footer">
                         <button class="btn btn-secondary" type="button" data-dismiss="modal">Close</button>
                         <button class="btn btn-primary" type="button" onclick="ClusterInfo.createNewTopic();">Create topic</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete topic modal -->
+        <div class="modal fade show" id="deleteTopicModal" tabindex="-1" role="dialog" aria-labelledby="myDeleteModalLabel" style="display: none;" sec:authorize="hasRole('ROLE_ADMIN')">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">Confirm topic removal</h4>
+                        <button class="close" type="button" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">×</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="warning">
+                            Deleting a topic is destructive and cannot be un-done!  <br/>
+                            <br/>
+                            To confirm permanently deleting topic <b id="removeTopicConfirm"></b> from cluster <b>[[${cluster.name}]]</b>, type the topic's name
+                            in the form below and click <i>Remove topic</i>.<br/>
+                            <br/>
+                        </div>
+
+                        <form method="post" class="form-horizontal">
+
+                            <!-- Name -->
+                            <div class="form-group row">
+                                <label class="col-md-3 form-control-label" for="topicName">
+                                    Confirm topic
+                                </label>
+                                <div class="col-md-9">
+                                    <input
+                                        id="removeTopicConfirmed" name="name" class="form-control" type="text">
+                                    <div class="invalid-feedback"></div>
+                                </div>
+                            </div>
+
+                        </form>
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-secondary" type="button" data-dismiss="modal">Close</button>
+                        <button class="btn btn-primary" type="button" onclick="ClusterInfo.confirmedRemoveTopic();">Remove topic</button>
                     </div>
                 </div>
             </div>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -196,6 +196,19 @@
                             ClusterInfo.loadTopics();
                         }
                     )
+                },
+                removeTopic : function(topicName) {
+                    if (!confirm('Are you sure you want to remove this topic? This is destructive and can NOT be un-done!')) {
+                        return;
+                    }
+                    ApiClient.removeTopic(
+                        ClusterInfo.clusterId,
+                        topicName,
+                        function(resultMsg) {
+                            UITools.showSuccess('Successfully removed topic.');
+                            ClusterInfo.loadTopics();
+                        }
+                    );
                 }
             };
 
@@ -299,6 +312,7 @@
                                 <th>Topic</th>
                                 <th>Partitions</th>
                                 <th>Status</th>
+                                <th sec:authorize="hasRole('ROLE_ADMIN')" class="text-right">Action</th>
                             </tr>
                             </thead>
                             <tbody id="topics-tbody">
@@ -389,6 +403,19 @@
                     {{#if internal}}
                         <span class="badge badge-info">Internal topic</span>
                     {{/if}}
+                </td>
+                <td class="text-right" sec:authorize="hasRole('ROLE_ADMIN')">
+                    <div class="dropdown">
+                        <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="fa fa-gear"></i>
+                        </button>
+                        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                            <a class="dropdown-item" onclick="return ClusterInfo.removeTopic('{{topic}}');">
+                                <i class="fa fa-remove"></i>
+                                Delete
+                            </a>
+                        </div>
+                    </div>
                 </td>
             </tr>
         </script>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -24,8 +24,19 @@
                 // Cached copy of consumers for client side searching
                 cachedConsumers: [],
 
+                // Cached copy of brokers for lcient side searching
+                cachedBrokers: [],
+
                 // Handle cluster node results ajax result
                 handleClusterNodeResults: function(results) {
+                    ClusterInfo.cachedBrokers = results;
+                    ClusterInfo.displayClusterNodes();
+                },
+                displayClusterNodes: function() {
+                    // Get our search text
+                    var searchStr = jQuery("#brokerSearch").val();
+                    var matchedEntries = 0;
+
                     // Clear nodes table
                     var table = jQuery('#nodes-tbody');
                     jQuery(table).empty();
@@ -34,7 +45,14 @@
                     var source   = jQuery('#nodes-template').html();
                     var template = Handlebars.compile(source);
 
-                    jQuery.each(results, function(index, result) {
+                    jQuery.each(ClusterInfo.cachedBrokers, function(index, result) {
+                        // Filter
+                        if (!SearchTools.doesMatchText(searchStr, result.host + ":" + result.port)) {
+                            // Skip
+                            return;
+                        }
+                        matchedEntries++;
+
                         // Generate html from template
                         var properties = {
                             clusterId: ClusterInfo.clusterId,
@@ -52,7 +70,7 @@
                     // Hide loader
                     jQuery('#nodes-loader').toggle(false);
 
-                    if (results.length == 0) {
+                    if (matchedEntries === 0) {
                         jQuery('#nodes-no-results').toggle(true);
                         jQuery('#nodes-table').toggle(false);
                     } else {
@@ -294,6 +312,16 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Cluster <strong th:text="${cluster.name}"></strong> Brokers
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="brokerSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="ClusterInfo.displayClusterNodes();">
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -347,7 +375,7 @@
                                 style="padding: 0px;"
                                 onkeyup="ClusterInfo.displayTopics();">
                             <a
-                                class="btn" href="#" style="padding-bottom: 0;"
+                                class="btn btn-sm" href="#" style="padding-bottom: 0;"
                                 data-toggle="modal" data-target="#createTopicModal"
                                 sec:authorize="hasRole('ROLE_ADMIN')">
                                 <i class="icon-settings"></i>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/read.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/read.html
@@ -17,6 +17,7 @@
             // Maintains state of our consumer
             var ClusterInfo = {
                 clusterId: '[[${cluster.id}]]',
+                cachedTopics: [],
 
                 // Handle cluster node results ajax result
                 handleClusterNodeResults: function(results) {
@@ -57,6 +58,15 @@
 
                 // Handle all topics details results ajax result
                 handleAllTopicsDetails: function(results) {
+                    ClusterInfo.cachedTopics = results;
+                    ClusterInfo.displayTopics();
+                },
+
+                displayTopics : function() {
+                    // Get our search text
+                    var searchStr = jQuery("#topicSearch").val();
+                    var matchedEntries = 0;
+
                     // Clear topics table
                     var table = jQuery('#topics-tbody');
                     jQuery(table).empty();
@@ -65,7 +75,15 @@
                     var source   = jQuery('#topics-template').html();
                     var template = Handlebars.compile(source);
 
-                    jQuery.each(results, function(index, result) {
+                    jQuery.each(ClusterInfo.cachedTopics, function(index, result) {
+                        // Filter
+                        if (searchStr != null && searchStr.length > 0) {
+                            if (result.name.toLowerCase().indexOf(searchStr.toLowerCase()) === -1) {
+                                return;
+                            }
+                        }
+                        matchedEntries++;
+
                         // Generate html from template
                         var properties = {
                             topic: result.name,
@@ -84,7 +102,7 @@
                     // Hide loader
                     jQuery('#topics-loader').toggle(false);
 
-                    if (results.length == 0) {
+                    if (matchedEntries === 0) {
                         jQuery('#topics-no-results').toggle(true);
                         jQuery('#topics-table').toggle(false);
                     } else {
@@ -300,8 +318,18 @@
                         <i class="fa fa-align-justify"></i>
                         Cluster <strong th:text="${cluster.name}"></strong> Topics
 
-                        <div class="btn-group float-right" role="group" aria-label="Button group" sec:authorize="hasRole('ROLE_ADMIN')">
-                            <a class="btn" href="#" style="padding-bottom: 0;" data-toggle="modal" data-target="#createTopicModal">
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="topicSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="ClusterInfo.displayTopics();">
+                            <a
+                                class="btn" href="#" style="padding-bottom: 0;"
+                                data-toggle="modal" data-target="#createTopicModal"
+                                sec:authorize="hasRole('ROLE_ADMIN')">
                                 <i class="icon-settings"></i>
                                 &nbsp;Create new
                             </a>

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readBroker.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readBroker.html
@@ -18,7 +18,20 @@
                 clusterId: '[[${cluster.id}]]',
                 brokerId: '[[${brokerId}]]',
 
+                // Cached topics for client side searching
+                cachedTopics: [],
+                cachedConfigResults: [],
+
                 handleClusterNodeResults: function(topics) {
+                    BrokerInfo.cachedTopics = topics;
+                    BrokerInfo.displayClusterNodeResults();
+                },
+
+                displayClusterNodeResults: function() {
+                    // Get our search text
+                    var searchStr = jQuery("#topicSearch").val();
+                    var matchedEntries = 0;
+
                     // Clear nodes table
                     var table = jQuery('#broker-tbody');
                     jQuery(table).empty();
@@ -31,13 +44,20 @@
                     var brokerHost = null;
 
                     // Loop over each topic
-                    jQuery(topics).each(function(topicIndex, topic) {
+                    jQuery(BrokerInfo.cachedTopics).each(function(topicIndex, topic) {
                         // Loop thru each partitions
                         jQuery(topic.partitions).each(function(partitionIndex, partition) {
                             var topicName = partition.topic;
                             var partitionId = partition.partition;
                             var role = null;
                             var inSync = false;
+
+                            // Filter
+                            if (!SearchTools.doesMatchText(searchStr, topicName)) {
+                                // Skip
+                                return;
+                            }
+                            matchedEntries++;
 
                             // If we're the leader
                             if (partition.leader != null && partition.leader.id == BrokerInfo.brokerId) {
@@ -86,15 +106,26 @@
                     // Hide loader
                     jQuery('#broker-loader').toggle(false);
 
-                    if (brokerHost == null) {
+                    if (brokerHost === null) {
                         jQuery('#broker-no-results').toggle(true);
+                        jQuery('#broker-table').toggle(false);
                     } else {
                         jQuery('.broker-host').text(brokerHost);
                         jQuery('#broker-no-results').toggle(false);
                         jQuery('#broker-table').toggle(true);
                     }
                 },
+
                 handleConfigResults: function(results) {
+                    BrokerInfo.cachedConfigResults = results;
+                    BrokerInfo.displayConfigResults();
+                },
+
+                displayConfigResults: function() {
+                    // Get our search text
+                    var searchStr = jQuery("#configSearch").val();
+                    var matchedEntries = 0;
+
                     // Clear topic table
                     var table = jQuery('#config-tbody');
                     jQuery(table).empty();
@@ -103,7 +134,17 @@
                     var source   = jQuery('#config-template').html();
                     var template = Handlebars.compile(source);
 
-                    jQuery(results).each(function(index, config) {
+                    jQuery(BrokerInfo.cachedConfigResults).each(function(index, config) {
+                        // Filter on name AND value
+                        if (
+                            !SearchTools.doesMatchText(searchStr, config.name) &&
+                            !SearchTools.doesMatchText(searchStr, config.value)
+                        ) {
+                            // Skip
+                            return;
+                        }
+                        matchedEntries++;
+
                         var properties = {
                             name: config.name,
                             value: config.value,
@@ -119,8 +160,9 @@
                     // Hide loader
                     jQuery('#config-loader').toggle(false);
 
-                    if (results.length == 0) {
+                    if (matchedEntries === 0) {
                         jQuery('#config-no-results').toggle(true);
+                        jQuery('#config-table').toggle(false);
                     } else {
                         jQuery('#config-no-results').toggle(false);
                         jQuery('#config-table').toggle(true);
@@ -153,6 +195,16 @@
                         <i class="fa fa-align-justify"></i>
                         Broker <strong th:text="${brokerId}"></strong> <strong class="broker-host"></strong>
                         on Cluster <strong th:text="${cluster.name}"></strong>
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="topicSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="BrokerInfo.displayClusterNodeResults();">
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -198,6 +250,16 @@
                         <i class="fa fa-align-justify"></i>
                         Broker <strong th:text="${brokerId}"></strong> <strong class="broker-host"></strong> Configuration
                         on Cluster <strong th:text="${cluster.name}"></strong>
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="configSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="BrokerInfo.displayConfigResults();">
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->
@@ -213,8 +275,8 @@
 
                         <!-- No Results Found -->
                         <div class="alert alert-light" role="alert" id="config-no-results" style="display: none;">
-                            <h4 class="alert-heading">Broker Not Found</h4>
-                            <p>Looks like we couldn't find any information about this broker!</p>
+                            <h4 class="alert-heading">No Configurations Found</h4>
+                            <p>Looks like we couldn't find any configurations on this broker!</p>
                         </div>
 
                         <!-- Hide Results Table -->

--- a/kafka-webview-ui/src/main/resources/templates/cluster/readTopic.html
+++ b/kafka-webview-ui/src/main/resources/templates/cluster/readTopic.html
@@ -19,6 +19,9 @@
                 clusterId: '[[${cluster.id}]]',
                 topic: '[[${topic}]]',
 
+                // Cached topic config for client side filtering
+                cachedTopicConfig: [],
+
                 handleTopicDetails: function(results) {
                     // Clear topic table
                     var table = jQuery('#topic-tbody');
@@ -73,7 +76,17 @@
                         jQuery('#topic-table').toggle(true);
                     }
                 },
+
                 handleConfigResults: function(results) {
+                    TopicInfo.cachedTopicConfig = results;
+                    TopicInfo.displayConfigResults();
+                },
+
+                displayConfigResults: function() {
+                    // Get our search text
+                    var searchStr = jQuery("#configSearch").val();
+                    var matchedEntries = 0;
+
                     // Clear topic table
                     var table = jQuery('#config-tbody');
                     jQuery(table).empty();
@@ -82,7 +95,17 @@
                     var source   = jQuery('#config-template').html();
                     var template = Handlebars.compile(source);
 
-                    jQuery(results).each(function(index, config) {
+                    jQuery(TopicInfo.cachedTopicConfig).each(function(index, config) {
+                        // Filter
+                        if (
+                            !SearchTools.doesMatchText(searchStr, config.name) &&
+                            !SearchTools.doesMatchText(searchStr, config.value)
+                        ) {
+                            // Skip
+                            return;
+                        }
+                        matchedEntries++;
+
                         var properties = {
                             name: config.name,
                             value: config.value,
@@ -98,8 +121,9 @@
                     // Hide loader
                     jQuery('#config-loader').toggle(false);
 
-                    if (results.length == 0) {
+                    if (matchedEntries === 0) {
                         jQuery('#config-no-results').toggle(true);
+                        jQuery('#config-table').toggle(false);
                     } else {
                         jQuery('#config-no-results').toggle(false);
                         jQuery('#config-table').toggle(true);
@@ -201,6 +225,16 @@
                     <div class="card-header">
                         <i class="fa fa-align-justify"></i>
                         Topic <strong th:text="${topic}"></strong> Configuration on Cluster <strong th:text="${cluster.name}"></strong>
+
+                        <div class="btn-group float-right" role="group" aria-label="Button group">
+                            <input
+                                th:type="text"
+                                th:id="configSearch"
+                                placeholder="Search..."
+                                size="15"
+                                style="padding: 0px;"
+                                onkeyup="TopicInfo.displayConfigResults();">
+                        </div>
                     </div>
                     <div class="card-body">
                         <!-- Display Loader First -->

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -198,8 +198,9 @@ public class ApiControllerTest extends AbstractMvcTest {
 
     /**
      * Test the delete topic end point.
+     * @TODO explicitly disabled until custom user roles. https://github.com/SourceLabOrg/kafka-webview/issues/157
      */
-    @Test
+    //@Test
     @Transactional
     public void test_deleteTopic() throws Exception {
         // Define our new topic name

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/controller/api/ApiControllerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -456,6 +457,99 @@ public class ApiControllerTest extends AbstractMvcTest {
             .andExpect(content().string(containsString("\"topic\":\"TestTopic-")))
             .andExpect(content().string(containsString("\"offsets\":[{\"partition\":0,\"offset\":10,\"tail\":10}]")))
             .andExpect(content().string(containsString("\"partitions\":[0]")));
+    }
+
+    /**
+     * Test listing topics without a search string.
+     */
+    @Test
+    @Transactional
+    public void test_listTopics_noSearchString() throws Exception {
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        // Create some topics
+        final String expectedTopic1 = "A-ExpectedTopic1-" + System.currentTimeMillis();
+        final String expectedTopic2= "C-ExpectedTopic2-" + System.currentTimeMillis();
+        final String expectedTopic3 = "B-ExpectedTopic3-" + System.currentTimeMillis();
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic1, 1, (short) 1);
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic2, 1, (short) 1);
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic3, 1, (short) 1);
+
+        // Hit end point
+        mockMvc
+            .perform(get("/api/cluster/" + cluster.getId() + "/topics/list")
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Validate all topics show up.
+            .andExpect(content().string(containsString(expectedTopic1)))
+            .andExpect(content().string(containsString(expectedTopic2)))
+            .andExpect(content().string(containsString(expectedTopic3)));
+    }
+
+    /**
+     * Test listing topics with a search string only returns filtered results.
+     */
+    @Test
+    @Transactional
+    public void test_listTopics_withSearchString() throws Exception {
+        // Create a cluster.
+        final Cluster cluster = clusterTestTools.createCluster(
+            "Test Cluster",
+            sharedKafkaTestResource.getKafkaConnectString()
+        );
+
+        final String searchStr = "CaT";
+
+        // Create some topics
+        final String expectedTopic1 = "ExpectedTopic1-" + System.currentTimeMillis();
+        final String expectedTopic2= "ExpectedCATTopic2-" + System.currentTimeMillis();
+        final String expectedTopic3 = "ExpectedTopic3-" + System.currentTimeMillis();
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic1, 1, (short) 1);
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic2, 1, (short) 1);
+
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(expectedTopic3, 1, (short) 1);
+
+        // Hit end point
+        mockMvc
+            .perform(get("/api/cluster/" + cluster.getId() + "/topics/list")
+                .param("search", searchStr)
+                .with(user(nonAdminUserDetails))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+
+            // Validate Only the filtered instance shows up.
+            .andExpect(content().string(containsString(expectedTopic2)))
+            .andExpect(content().string(Matchers.not(containsString(expectedTopic1))))
+            .andExpect(content().string(Matchers.not(containsString(expectedTopic3))));
     }
 
     /**

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/KafkaOperationsTest.java
@@ -346,6 +346,31 @@ public class KafkaOperationsTest {
     }
 
     /**
+     * Test creating a new topic.
+     */
+    @Test
+    public void testRemoveTopic() {
+        final String newTopic = "TestTopic-" + System.currentTimeMillis();
+
+        // Create topic
+        sharedKafkaTestResource
+            .getKafkaTestUtils()
+            .createTopic(newTopic, 1, (short) 1);
+
+        // Validate topic exists now.
+        TopicList topicsList = kafkaOperations.getAvailableTopics();
+        assertTrue("Should contain our topic now", topicsList.getTopicNames().contains(newTopic));
+
+        // Attempt to remove the topic
+        final boolean result = kafkaOperations.removeTopic(newTopic);
+        assertTrue("Should have returned true", result);
+
+        // Validate our topic doesn't exist
+        topicsList = kafkaOperations.getAvailableTopics();
+        assertFalse("Should not contain our topic anymore", topicsList.getTopicNames().contains(newTopic));
+    }
+
+    /**
      * Test listing consumer group ids.
      */
     @Test

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicListTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/dto/TopicListTest.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TopicListTest {
 
@@ -101,5 +103,60 @@ public class TopicListTest {
         // Should be immutable.
         expectedException.expect(UnsupportedOperationException.class);
         results.remove(1);
+    }
+
+    /**
+     * Validates if you filter by null, it returns empty.
+     */
+    @Test
+    public void testFilterByTopicName_nullValueReturnsEmpty() {
+        final List<TopicListing> topicListingList = new ArrayList<>();
+        topicListingList.add(new TopicListing("A", false));
+        topicListingList.add(new TopicListing("B", false));
+        topicListingList.add(new TopicListing("C", false));
+
+        // Create instance
+        final TopicList topicList = new TopicList(topicListingList);
+        final TopicList filtered = topicList.filterByTopicName(null);
+
+        // Validate original listing not modified.
+        final List<String> results = topicList.getTopicNames();
+        assertEquals("A", results.get(0));
+        assertEquals("B", results.get(1));
+        assertEquals("C", results.get(2));
+
+        // Validate filtered is empty because we passed null.
+        assertTrue("Should be empty", filtered.getTopicNames().isEmpty());
+        assertTrue("Should be empty", filtered.getTopics().isEmpty());
+    }
+
+    /**
+     * Validates if you filter it is not case sensitive.
+     */
+    @Test
+    public void testFilterByTopicName_canFilter() {
+        final List<TopicListing> topicListingList = new ArrayList<>();
+        topicListingList.add(new TopicListing("A Cat In The HAT", false));
+        topicListingList.add(new TopicListing("Hat Man", false));
+        topicListingList.add(new TopicListing("Something Else", false));
+
+        // Create instance
+        final TopicList topicList = new TopicList(topicListingList);
+        final TopicList filtered = topicList.filterByTopicName("at");
+
+        // Validate original listing not modified.
+        List<String> results = topicList.getTopicNames();
+        assertEquals("A Cat In The HAT", results.get(0));
+        assertEquals("Hat Man", results.get(1));
+        assertEquals("Something Else", results.get(2));
+
+        // Validate filtered is empty because we passed null.
+        assertFalse("Should not be empty", filtered.getTopicNames().isEmpty());
+        assertEquals(2, filtered.getTopicNames().size());
+        assertEquals(2, filtered.getTopics().size());
+
+        results = filtered.getTopicNames();
+        assertEquals("A Cat In The HAT", results.get(0));
+        assertEquals("Hat Man", results.get(1));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
 
     <!-- Define submodules -->
     <modules>


### PR DESCRIPTION
for #142 Add the ability to search topics within a cluster, as well as remove topics if the user has the Administrator role.

Since the ability to remove topics is potentially extremely destructive, we are holding back this functionality from being accessed until custom user roles has been released.  