### PR TITLE
Add new Parallel capable web consumer.  Disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.0 (UNRELEASED)
+#### New Features
+- [MultiThreaded Consumer](https://github.com/SourceLabOrg/kafka-webview/pull/170) Add multi-threaded kafka consumer.  
+
+Previously a single consumer instance was used when paging through messages from a topic.  Each partition was consumed sequentially in order to provide consistent results on each page.  For topics with a large number of partitions this could take considerable time.
+
+The underlying consumer implementation has been replaced with a multi-threaded version which will attempt to read each partition in parallel.  The following configuration properties have been added to control this behavior:
+
+```yml
+app:
+  ## Enable multi-threaded consumer support
+  ## The previous single-threaded implementation is still available by setting this property to false.
+  ## The previous implementation along with this property will be removed in future release.
+  multiThreadedConsumer: true
+
+  ## Sets upper limit on the number of concurrent consumers (non-websocket) supported.
+  maxConcurrentWebConsumers: 32
+```
+
+If you run into issues, you can disable the new implementation and revert to the previous behavior by setting the `multiThreadedConsumer` property to `false`.
+
 ## 2.2.0 (03/20/2019)
 
 #### Bug fixes

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ app:
 
   ## Defines a prefix prepended to the Id of all consumers.
   consumerIdPrefix: "KafkaWebViewConsumer"
+  
+  ## Enable multi-threaded consumer support
+  ## The previous single-threaded implementation is still available by setting this property to false.
+  ## The previous implementation along with this property will be removed in future release.
+  multiThreadedConsumer: true
+  
+  ## Sets upper limit on the number of concurrent consumers (non-websocket) supported.
+  maxConcurrentWebConsumers: 32
 
   ## Sets upper limit on the number of concurrent web socket consumers supported.
   maxConcurrentWebSocketConsumers: 64
@@ -299,8 +307,8 @@ implementations.
 # Releasing
 Steps for performing a release:
 
-1. Update release version: mvn versions:set -DnewVersion=X.Y.Z
-2. Validate and then commit version: mvn versions:commit
+1. Update release version: `mvn versions:set -DnewVersion=X.Y.Z`
+2. Validate and then commit version: `mvn versions:commit`
 3. Update CHANGELOG and README files.
 4. Merge to master.
 5. Deploy to Maven Central: mvn clean deploy -P release-kafka-webview

--- a/dev-cluster/pom.xml
+++ b/dev-cluster/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dev-cluster</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 
     <!-- Require Maven 3.3.9 -->
     <prerequisites>

--- a/kafka-webview-plugin/pom.xml
+++ b/kafka-webview-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sourcelab</groupId>
         <artifactId>kafka-webview</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-plugin</artifactId>

--- a/kafka-webview-ui/pom.xml
+++ b/kafka-webview-ui/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>kafka-webview</artifactId>
         <groupId>org.sourcelab</groupId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kafka-webview-ui</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 
     <!-- Module Description and Ownership -->
     <name>Kafka WebView UI</name>

--- a/kafka-webview-ui/src/assembly/distribution/config.yml
+++ b/kafka-webview-ui/src/assembly/distribution/config.yml
@@ -16,6 +16,15 @@ app:
   ## Defines a prefix prepended to the Id of all consumers.
   consumerIdPrefix: "KafkaWebViewConsumer"
 
+  ## Enable multi-threaded consumer support
+  ## Currently in Beta, so disabled by default.  If you have issues with slow consuming
+  ## it's recommended you try turning this feature on.
+  multiThreadedConsumer: false
+
+  ## Sets upper limit on the number of concurrent consumers (non-websocket) supported.
+  ## Only relevant when the 'multiThreadedConsumer' option is enabled.
+  maxConcurrentWebConsumers: 32
+
   ## Sets upper limit on the number of concurrent web socket consumers supported.
   maxConcurrentWebSocketConsumers: 64
 

--- a/kafka-webview-ui/src/assembly/distribution/config.yml
+++ b/kafka-webview-ui/src/assembly/distribution/config.yml
@@ -17,12 +17,11 @@ app:
   consumerIdPrefix: "KafkaWebViewConsumer"
 
   ## Enable multi-threaded consumer support
-  ## Currently in Beta, so disabled by default.  If you have issues with slow consuming
-  ## it's recommended you try turning this feature on.
-  multiThreadedConsumer: false
+  ## The previous single-threaded implementation is still available by setting this property to false.
+  ## The previous implementation along with this property will be removed in future release.
+  multiThreadedConsumer: true
 
   ## Sets upper limit on the number of concurrent consumers (non-websocket) supported.
-  ## Only relevant when the 'multiThreadedConsumer' option is enabled.
   maxConcurrentWebConsumers: 32
 
   ## Sets upper limit on the number of concurrent web socket consumers supported.

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/AppProperties.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/AppProperties.java
@@ -43,7 +43,7 @@ public class AppProperties {
     @Value("${app.key}")
     private String appKey;
 
-    @Value("${app.multiThreadedConsumer:false}")
+    @Value("${app.multiThreadedConsumer:true}")
     private boolean enableMultiThreadedConsumer;
 
     @Value("${app.maxConcurrentWebConsumers:32}")

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/AppProperties.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/configuration/AppProperties.java
@@ -43,7 +43,13 @@ public class AppProperties {
     @Value("${app.key}")
     private String appKey;
 
-    @Value("${app.maxConcurrentWebSocketConsumers}")
+    @Value("${app.multiThreadedConsumer:false}")
+    private boolean enableMultiThreadedConsumer;
+
+    @Value("${app.maxConcurrentWebConsumers:32}")
+    private Integer maxConcurrentWebConsumers = 32;
+
+    @Value("${app.maxConcurrentWebSocketConsumers:100}")
     private Integer maxConcurrentWebSocketConsumers = 100;
 
     @Value("${app.consumerIdPrefix}")
@@ -102,6 +108,14 @@ public class AppProperties {
 
     public boolean isAvroIncludeSchema() {
         return avroIncludeSchema;
+    }
+
+    public boolean isEnableMultiThreadedConsumer() {
+        return enableMultiThreadedConsumer;
+    }
+
+    public Integer getMaxConcurrentWebConsumers() {
+        return maxConcurrentWebConsumers;
     }
 
     @Override

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/DefaultWebKafkaConsumer.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/DefaultWebKafkaConsumer.java
@@ -1,0 +1,348 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018, 2019 SourceLab.org (https://github.com/SourceLabOrg/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.sourcelab.kafka.webview.ui.manager.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClientConfig;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResult;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.PartitionOffset;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Wrapper around KafkaConsumer.  This instance is intended to be short lived and only live
+ * during the life-time of a single web request.
+ *
+ * @deprecated Soon to be replaced by {@link ParallelWebKafkaConsumer} for its better performance.
+ */
+@Deprecated
+public class DefaultWebKafkaConsumer implements WebKafkaConsumer {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultWebKafkaConsumer.class);
+
+    private final KafkaConsumer kafkaConsumer;
+    private final ClientConfig clientConfig;
+    private List<TopicPartition> cachedTopicsAndPartitions = null;
+    private final Duration pollTimeoutDuration;
+
+    /**
+     * Constructor.
+     * @param kafkaConsumer The underlying/wrapped KafkaConsumer instance.
+     * @param clientConfig The client configuration.
+     */
+    public DefaultWebKafkaConsumer(final KafkaConsumer kafkaConsumer, final ClientConfig clientConfig) {
+        this.kafkaConsumer = kafkaConsumer;
+        this.clientConfig = clientConfig;
+        this.pollTimeoutDuration = Duration.ofMillis(clientConfig.getPollTimeoutMs());
+    }
+
+    private List<KafkaResult> consume() {
+        final List<KafkaResult> kafkaResultList = new ArrayList<>();
+        final ConsumerRecords consumerRecords = kafkaConsumer.poll(pollTimeoutDuration);
+
+        logger.info("Consumed {} records", consumerRecords.count());
+        final Iterator<ConsumerRecord> recordIterator = consumerRecords.iterator();
+        while (recordIterator.hasNext()) {
+            // Get next record
+            final ConsumerRecord consumerRecord = recordIterator.next();
+
+            // Convert to KafkaResult.
+            final KafkaResult kafkaResult = new KafkaResult(
+                consumerRecord.partition(),
+                consumerRecord.offset(),
+                consumerRecord.timestamp(),
+                consumerRecord.key(),
+                consumerRecord.value()
+            );
+
+            // Add to list.
+            kafkaResultList.add(kafkaResult);
+        }
+
+        // Commit offsets
+        commit();
+        return kafkaResultList;
+    }
+
+    /**
+     * Retrieves next batch of records per partition.
+     * @return KafkaResults object containing any found records.
+     */
+    @Override
+    public KafkaResults consumePerPartition() {
+        final Map<Integer, List<KafkaResult>> resultsByPartition = new TreeMap<>();
+        for (final TopicPartition topicPartition: getAllPartitions()) {
+            // Subscribe to just that topic partition
+            kafkaConsumer.assign(Collections.singleton(topicPartition));
+
+            // consume
+            final List<KafkaResult> kafkaResults = consume();
+
+            logger.info("Consumed Partition {} Records: {}", topicPartition.partition(), kafkaResults.size());
+            resultsByPartition.put(topicPartition.partition(), kafkaResults);
+        }
+
+        // Reassign all partitions
+        kafkaConsumer.assign(getAllPartitions());
+
+        // Loop over results
+        final List<KafkaResult> allResults = new ArrayList<>();
+        for (final List<KafkaResult> results: resultsByPartition.values()) {
+            allResults.addAll(results);
+        }
+
+        // Create return object
+        return new KafkaResults(
+            allResults,
+            getConsumerState().getOffsets(),
+            getHeadOffsets(),
+            getTailOffsets()
+        );
+    }
+
+    /**
+     * Seek to the specified offsets.
+     * @param partitionOffsetMap Map of PartitionId to Offset to seek to.
+     * @return ConsumerState representing the consumer's positions.
+     */
+    @Override
+    public ConsumerState seek(final Map<Integer, Long> partitionOffsetMap) {
+        for (final Map.Entry<Integer, Long> entry: partitionOffsetMap.entrySet()) {
+            kafkaConsumer.seek(
+                new TopicPartition(clientConfig.getTopicConfig().getTopicName(), entry.getKey()),
+                entry.getValue()
+            );
+        }
+        commit();
+        return getConsumerState();
+    }
+
+    /**
+     * Seek consumer to specific timestamp
+     * @param timestamp Unix timestamp in milliseconds to seek to.
+     */
+    @Override
+    public ConsumerState seek(final long timestamp) {
+        // Find offsets for timestamp
+        final Map<TopicPartition, Long> timestampMap = new HashMap<>();
+        for (final TopicPartition topicPartition: getAllPartitions()) {
+            timestampMap.put(topicPartition, timestamp);
+        }
+        final Map<TopicPartition, OffsetAndTimestamp> offsetMap = kafkaConsumer.offsetsForTimes(timestampMap);
+
+        // Build map of partition => offset
+        final Map<Integer, Long> partitionOffsetMap = new HashMap<>();
+        for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry: offsetMap.entrySet()) {
+            partitionOffsetMap.put(entry.getKey().partition(), entry.getValue().offset());
+        }
+
+        // Now lets seek to those offsets
+        return seek(partitionOffsetMap);
+    }
+
+    private List<PartitionOffset> getHeadOffsets() {
+        final Map<TopicPartition, Long> results = kafkaConsumer.beginningOffsets(getAllPartitions());
+
+        final List<PartitionOffset> offsets = new ArrayList<>();
+        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
+            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
+        }
+        return offsets;
+    }
+
+    private List<PartitionOffset> getTailOffsets() {
+        final Map<TopicPartition, Long> results = kafkaConsumer.endOffsets(getAllPartitions());
+
+        final List<PartitionOffset> offsets = new ArrayList<>();
+        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
+            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
+        }
+        return offsets;
+    }
+
+    private ConsumerState getConsumerState() {
+        final List<PartitionOffset> offsets = new ArrayList<>();
+
+        for (final TopicPartition topicPartition: getAllPartitions()) {
+            final long offset = kafkaConsumer.position(topicPartition);
+            offsets.add(new PartitionOffset(topicPartition.partition(), offset));
+        }
+
+        return new ConsumerState(clientConfig.getTopicConfig().getTopicName(), offsets);
+    }
+
+    private List<TopicPartition> getAllPartitions() {
+        // If we have not pulled this yet
+        if (cachedTopicsAndPartitions == null) {
+            // Determine which partitions to subscribe to, for now do all
+            final List<PartitionInfo> partitionInfos = kafkaConsumer.partitionsFor(clientConfig.getTopicConfig().getTopicName());
+
+            // Pull out partitions, convert to topic partitions
+            cachedTopicsAndPartitions = new ArrayList<>();
+            for (final PartitionInfo partitionInfo : partitionInfos) {
+                // Skip filtered partitions
+                if (!clientConfig.isPartitionFiltered(partitionInfo.partition())) {
+                    cachedTopicsAndPartitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+                }
+            }
+        }
+        return cachedTopicsAndPartitions;
+    }
+
+    private void commit() {
+        kafkaConsumer.commitSync();
+    }
+
+    /**
+     * Closes out the consumer.
+     */
+    @Override
+    public void close() {
+        kafkaConsumer.close();
+    }
+
+    /**
+     * Seek to the previous 'page' of records.
+     */
+    @Override
+    public void previous() {
+        // Get all available partitions
+        final List<TopicPartition> topicPartitions = getAllPartitions();
+
+        // Get head offsets for each partition
+        final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
+
+        // Loop over each partition
+        for (final TopicPartition topicPartition: topicPartitions) {
+            // Calculate our previous offsets
+            final long headOffset = headOffsets.get(topicPartition);
+            final long currentOffset = kafkaConsumer.position(topicPartition);
+            long newOffset = currentOffset - (clientConfig.getMaxResultsPerPartition() * 2);
+
+            // Can't go before the head position!
+            if (newOffset < headOffset) {
+                newOffset = headOffset;
+            }
+
+            logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
+
+            // Seek to earlier offset
+            kafkaConsumer.seek(topicPartition, newOffset);
+        }
+        commit();
+    }
+
+    /**
+     * Seek to the next 'page' of records.
+     */
+    @Override
+    public void next() {
+        // Get all available partitions
+        final List<TopicPartition> topicPartitions = getAllPartitions();
+
+        // Get head offsets for each partition
+        final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
+
+        // Loop over each partition
+        for (final TopicPartition topicPartition: topicPartitions) {
+            // Calculate our previous offsets
+            final long tailOffset = tailOffsets.get(topicPartition);
+            final long currentOffset = kafkaConsumer.position(topicPartition);
+            long newOffset = currentOffset + clientConfig.getMaxResultsPerPartition();
+
+            if (newOffset < tailOffset) {
+                newOffset = tailOffset;
+            }
+            logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
+
+            // Seek to earlier offset
+            kafkaConsumer.seek(topicPartition, newOffset);
+        }
+        commit();
+    }
+
+    /**
+     * Seek to the HEAD of a topic.
+     */
+    @Override
+    public ConsumerState toHead() {
+        // Get all available partitions
+        final List<TopicPartition> topicPartitions = getAllPartitions();
+
+        // Get head offsets for each partition
+        final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
+
+        // Loop over each partition
+        for (final TopicPartition topicPartition: topicPartitions) {
+            final long newOffset = headOffsets.get(topicPartition);
+            logger.info("Resetting Partition: {} To Head Offset: {}", topicPartition.partition(), newOffset);
+
+            // Seek to earlier offset
+            kafkaConsumer.seek(topicPartition, newOffset);
+        }
+        commit();
+
+        return getConsumerState();
+    }
+
+    /**
+     * Seek to the TAIL of a topic.
+     */
+    @Override
+    public ConsumerState toTail() {
+        // Get all available partitions
+        final List<TopicPartition> topicPartitions = getAllPartitions();
+
+        // Get head offsets for each partition
+        final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
+
+        // Loop over each partition
+        for (final TopicPartition topicPartition: topicPartitions) {
+            final long newOffset = tailOffsets.get(topicPartition);
+            logger.info("Resetting Partition: {} To Tail Offset: {}", topicPartition.partition(), newOffset);
+
+            // Seek to earlier offset
+            kafkaConsumer.seek(topicPartition, newOffset);
+        }
+        commit();
+
+        return getConsumerState();
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/ParallelWebKafkaConsumer.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/ParallelWebKafkaConsumer.java
@@ -1,0 +1,369 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017, 2018, 2019 SourceLab.org (https://github.com/SourceLabOrg/kafka-webview/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.sourcelab.kafka.webview.ui.manager.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClientConfig;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResult;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
+import org.sourcelab.kafka.webview.ui.manager.kafka.dto.PartitionOffset;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Wrapper around KafkaConsumer.  This instance is intended to be short lived and only live
+ * during the life-time of a single web request.
+ *
+ * In order to provide a relatively "sane" ability to "page" through results in a consistent way, this
+ * consumes from each partition in parallel and merges the results.
+ *
+ * The parallelization factor is determined by the ExecutorService provided to the constructor.
+ */
+public class ParallelWebKafkaConsumer implements WebKafkaConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(ParallelWebKafkaConsumer.class);
+
+    private final KafkaConsumerFactory kafkaConsumerFactory;
+    private final ClientConfig clientConfig;
+    private final Duration pollTimeoutDuration;
+    private final ExecutorService executorService;
+
+    private List<TopicPartition> cachedTopicsAndPartitions = null;
+
+    /**
+     * Constructor.
+     * @param kafkaConsumerFactory Factor for creating KafkaConsumer instances.
+     * @param clientConfig Client configuration.
+     * @param executorService ExecutorService to submit parallel consuming tasks to.
+     */
+    public ParallelWebKafkaConsumer(
+        final KafkaConsumerFactory kafkaConsumerFactory,
+        final ClientConfig clientConfig,
+        final ExecutorService executorService
+    ) {
+        this.kafkaConsumerFactory = kafkaConsumerFactory;
+        this.clientConfig = clientConfig;
+        this.pollTimeoutDuration = Duration.ofMillis(clientConfig.getPollTimeoutMs());
+        this.executorService = executorService;
+    }
+
+    @Override
+    public KafkaResults consumePerPartition() {
+        final List<TopicPartition> allTopicPartitions;
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            allTopicPartitions = getAllPartitions(kafkaConsumer);
+        }
+
+        // To preserve order
+        final Map<Integer, CompletableFuture<List<KafkaResult>>> completableFuturesByPartition = new TreeMap<>();
+
+        for (final TopicPartition topicPartition : allTopicPartitions) {
+            final CompletableFuture<List<KafkaResult>> future = CompletableFuture.supplyAsync(() -> {
+                try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+                    // Subscribe to just that topic partition
+                    kafkaConsumer.assign(Collections.singleton(topicPartition));
+
+                    // consume
+                    return consume(kafkaConsumer);
+                }
+            }, executorService);
+            completableFuturesByPartition.put(topicPartition.partition(), future);
+        }
+
+        // Merge results.
+        final List<KafkaResult> allResults = new ArrayList<>();
+        completableFuturesByPartition.forEach((partition, future) -> {
+            allResults.addAll(future.join());
+        });
+
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Create return object
+            return new KafkaResults(
+                allResults,
+                getConsumerState(kafkaConsumer).getOffsets(),
+                getHeadOffsets(kafkaConsumer),
+                getTailOffsets(kafkaConsumer)
+            );
+        }
+    }
+
+    @Override
+    public ConsumerState seek(final Map<Integer, Long> partitionOffsetMap) {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            for (final Map.Entry<Integer, Long> entry : partitionOffsetMap.entrySet()) {
+                kafkaConsumer.seek(
+                    new TopicPartition(clientConfig.getTopicConfig().getTopicName(), entry.getKey()),
+                    entry.getValue()
+                );
+            }
+            commit(kafkaConsumer);
+            return getConsumerState(kafkaConsumer);
+        }
+    }
+
+    @Override
+    public ConsumerState seek(final long timestamp) {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Find offsets for timestamp
+            final Map<TopicPartition, Long> timestampMap = new HashMap<>();
+            for (final TopicPartition topicPartition : getAllPartitions(kafkaConsumer)) {
+                timestampMap.put(topicPartition, timestamp);
+            }
+            final Map<TopicPartition, OffsetAndTimestamp> offsetMap = kafkaConsumer.offsetsForTimes(timestampMap);
+
+            // Build map of partition => offset
+            final Map<Integer, Long> partitionOffsetMap = new HashMap<>();
+            for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry : offsetMap.entrySet()) {
+                partitionOffsetMap.put(entry.getKey().partition(), entry.getValue().offset());
+            }
+
+            // Now lets seek to those offsets
+            return seek(partitionOffsetMap);
+        }
+    }
+
+    @Override
+    public void close() {
+        // no-op.
+        // Since a single ExecutorService is shared between instances of this class,
+        // we should not close it out.
+    }
+
+    @Override
+    public void previous() {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Get all available partitions
+            final List<TopicPartition> topicPartitions = getAllPartitions(kafkaConsumer);
+
+            // Get head offsets for each partition
+            final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
+
+            // Loop over each partition
+            for (final TopicPartition topicPartition : topicPartitions) {
+                // Calculate our previous offsets
+                final long headOffset = headOffsets.get(topicPartition);
+                final long currentOffset = kafkaConsumer.position(topicPartition);
+                long newOffset = currentOffset - (clientConfig.getMaxResultsPerPartition() * 2);
+
+                // Can't go before the head position!
+                if (newOffset < headOffset) {
+                    newOffset = headOffset;
+                }
+
+                logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
+
+                // Seek to earlier offset
+                kafkaConsumer.seek(topicPartition, newOffset);
+            }
+            commit(kafkaConsumer);
+        }
+    }
+
+    @Override
+    public void next() {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Get all available partitions
+            final List<TopicPartition> topicPartitions = getAllPartitions(kafkaConsumer);
+
+            // Get head offsets for each partition
+            final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
+
+            // Loop over each partition
+            for (final TopicPartition topicPartition : topicPartitions) {
+                // Calculate our previous offsets
+                final long tailOffset = tailOffsets.get(topicPartition);
+                final long currentOffset = kafkaConsumer.position(topicPartition);
+                long newOffset = currentOffset + clientConfig.getMaxResultsPerPartition();
+
+                if (newOffset < tailOffset) {
+                    newOffset = tailOffset;
+                }
+                logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
+
+                // Seek to earlier offset
+                kafkaConsumer.seek(topicPartition, newOffset);
+            }
+            commit(kafkaConsumer);
+        }
+    }
+
+    @Override
+    public ConsumerState toHead() {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Get all available partitions
+            final List<TopicPartition> topicPartitions = getAllPartitions(kafkaConsumer);
+
+            // Get head offsets for each partition
+            final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
+
+            // Loop over each partition
+            for (final TopicPartition topicPartition : topicPartitions) {
+                final long newOffset = headOffsets.get(topicPartition);
+                logger.info("Resetting Partition: {} To Head Offset: {}", topicPartition.partition(), newOffset);
+
+                // Seek to earlier offset
+                kafkaConsumer.seek(topicPartition, newOffset);
+            }
+            commit(kafkaConsumer);
+            return getConsumerState(kafkaConsumer);
+        }
+    }
+
+    @Override
+    public ConsumerState toTail() {
+        try (final KafkaConsumer kafkaConsumer = createNewConsumer()) {
+            // Get all available partitions
+            final List<TopicPartition> topicPartitions = getAllPartitions(kafkaConsumer);
+
+            // Get head offsets for each partition
+            final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
+
+            // Loop over each partition
+            for (final TopicPartition topicPartition : topicPartitions) {
+                final long newOffset = tailOffsets.get(topicPartition);
+                logger.info("Resetting Partition: {} To Tail Offset: {}", topicPartition.partition(), newOffset);
+
+                // Seek to earlier offset
+                kafkaConsumer.seek(topicPartition, newOffset);
+            }
+            commit(kafkaConsumer);
+
+            return getConsumerState(kafkaConsumer);
+        }
+    }
+
+    private KafkaConsumer createNewConsumer() {
+        return kafkaConsumerFactory.createConsumerAndSubscribe(clientConfig);
+    }
+
+    private ConsumerState getConsumerState(final KafkaConsumer kafkaConsumer) {
+        final List<PartitionOffset> offsets = new ArrayList<>();
+
+        for (final TopicPartition topicPartition: getAllPartitions(kafkaConsumer)) {
+            final long offset = kafkaConsumer.position(topicPartition);
+            offsets.add(new PartitionOffset(topicPartition.partition(), offset));
+        }
+
+        return new ConsumerState(clientConfig.getTopicConfig().getTopicName(), offsets);
+    }
+
+    /**
+     * Mark synchronized to prevent multi-threaded weirdness.
+     */
+    private List<TopicPartition> getAllPartitions(final KafkaConsumer kafkaConsumer) {
+        // If we have not pulled this yet
+        if (cachedTopicsAndPartitions == null) {
+            // Attempt to prevent multi-threaded weirdness.
+            synchronized (this) {
+                if (cachedTopicsAndPartitions == null) {
+                    // Determine which partitions to subscribe to, for now do all
+                    final List<PartitionInfo> partitionInfos = kafkaConsumer.partitionsFor(clientConfig.getTopicConfig().getTopicName());
+
+                    // Pull out partitions, convert to topic partitions
+                    final List<TopicPartition> tempHolder = new ArrayList<>();
+                    for (final PartitionInfo partitionInfo : partitionInfos) {
+                        // Skip filtered partitions
+                        if (!clientConfig.isPartitionFiltered(partitionInfo.partition())) {
+                            tempHolder.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+                        }
+                    }
+                    cachedTopicsAndPartitions = Collections.unmodifiableList(tempHolder);
+                }
+            }
+
+        }
+        return cachedTopicsAndPartitions;
+    }
+
+    private List<PartitionOffset> getHeadOffsets(final KafkaConsumer kafkaConsumer) {
+        final Map<TopicPartition, Long> results = kafkaConsumer.beginningOffsets(getAllPartitions(kafkaConsumer));
+
+        final List<PartitionOffset> offsets = new ArrayList<>();
+        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
+            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
+        }
+        return offsets;
+    }
+
+    private List<PartitionOffset> getTailOffsets(final KafkaConsumer kafkaConsumer) {
+        final Map<TopicPartition, Long> results = kafkaConsumer.endOffsets(getAllPartitions(kafkaConsumer));
+
+        final List<PartitionOffset> offsets = new ArrayList<>();
+        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
+            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
+        }
+        return offsets;
+    }
+
+
+    private void commit(final KafkaConsumer kafkaConsumer) {
+        kafkaConsumer.commitSync();
+    }
+
+    private List<KafkaResult> consume(final KafkaConsumer kafkaConsumer) {
+        final List<KafkaResult> kafkaResultList = new ArrayList<>();
+        final ConsumerRecords consumerRecords = kafkaConsumer.poll(pollTimeoutDuration);
+
+        logger.info("Consumed {} records", consumerRecords.count());
+        final Iterator<ConsumerRecord> recordIterator = consumerRecords.iterator();
+        while (recordIterator.hasNext()) {
+            // Get next record
+            final ConsumerRecord consumerRecord = recordIterator.next();
+
+            // Convert to KafkaResult.
+            final KafkaResult kafkaResult = new KafkaResult(
+                consumerRecord.partition(),
+                consumerRecord.offset(),
+                consumerRecord.timestamp(),
+                consumerRecord.key(),
+                consumerRecord.value()
+            );
+
+            // Add to list.
+            kafkaResultList.add(kafkaResult);
+        }
+
+        // Commit offsets
+        commit(kafkaConsumer);
+        return kafkaResultList;
+    }
+}

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumer.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumer.java
@@ -24,314 +24,57 @@
 
 package org.sourcelab.kafka.webview.ui.manager.kafka;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sourcelab.kafka.webview.ui.manager.kafka.config.ClientConfig;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.ConsumerState;
-import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResult;
 import org.sourcelab.kafka.webview.ui.manager.kafka.dto.KafkaResults;
-import org.sourcelab.kafka.webview.ui.manager.kafka.dto.PartitionOffset;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
- * Wrapper around KafkaConsumer.  This instance is intended to be short lived and only live
- * during the life-time of a single web request.
+ * Interface for a KafkaConsumer used for consuming from Kafka from on-line web requests.
  */
-public class WebKafkaConsumer implements AutoCloseable {
-    private static final Logger logger = LoggerFactory.getLogger(WebKafkaConsumer.class);
-
-    private final KafkaConsumer kafkaConsumer;
-    private final ClientConfig clientConfig;
-    private List<TopicPartition> cachedTopicsAndPartitions = null;
-    private final Duration pollTimeoutDuration;
-
-    /**
-     * Constructor.
-     * @param kafkaConsumer The underlying/wrapped KafkaConsumer instance.
-     * @param clientConfig The client configuration.
-     */
-    public WebKafkaConsumer(final KafkaConsumer kafkaConsumer, final ClientConfig clientConfig) {
-        this.kafkaConsumer = kafkaConsumer;
-        this.clientConfig = clientConfig;
-        this.pollTimeoutDuration = Duration.ofMillis(clientConfig.getPollTimeoutMs());
-    }
-
-    private List<KafkaResult> consume() {
-        final List<KafkaResult> kafkaResultList = new ArrayList<>();
-        final ConsumerRecords consumerRecords = kafkaConsumer.poll(pollTimeoutDuration);
-
-        logger.info("Consumed {} records", consumerRecords.count());
-        final Iterator<ConsumerRecord> recordIterator = consumerRecords.iterator();
-        while (recordIterator.hasNext()) {
-            // Get next record
-            final ConsumerRecord consumerRecord = recordIterator.next();
-
-            // Convert to KafkaResult.
-            final KafkaResult kafkaResult = new KafkaResult(
-                consumerRecord.partition(),
-                consumerRecord.offset(),
-                consumerRecord.timestamp(),
-                consumerRecord.key(),
-                consumerRecord.value()
-            );
-
-            // Add to list.
-            kafkaResultList.add(kafkaResult);
-        }
-
-        // Commit offsets
-        commit();
-        return kafkaResultList;
-    }
+public interface WebKafkaConsumer extends AutoCloseable {
 
     /**
      * Retrieves next batch of records per partition.
      * @return KafkaResults object containing any found records.
      */
-    public KafkaResults consumePerPartition() {
-        final Map<Integer, List<KafkaResult>> resultsByPartition = new TreeMap<>();
-        for (final TopicPartition topicPartition: getAllPartitions()) {
-            // Subscribe to just that topic partition
-            kafkaConsumer.assign(Collections.singleton(topicPartition));
-
-            // consume
-            final List<KafkaResult> kafkaResults = consume();
-
-            logger.info("Consumed Partition {} Records: {}", topicPartition.partition(), kafkaResults.size());
-            resultsByPartition.put(topicPartition.partition(), kafkaResults);
-        }
-
-        // Reassign all partitions
-        kafkaConsumer.assign(getAllPartitions());
-
-        // Loop over results
-        final List<KafkaResult> allResults = new ArrayList<>();
-        for (final List<KafkaResult> results: resultsByPartition.values()) {
-            allResults.addAll(results);
-        }
-
-        // Create return object
-        return new KafkaResults(
-            allResults,
-            getConsumerState().getOffsets(),
-            getHeadOffsets(),
-            getTailOffsets()
-        );
-    }
+    KafkaResults consumePerPartition();
 
     /**
      * Seek to the specified offsets.
      * @param partitionOffsetMap Map of PartitionId to Offset to seek to.
      * @return ConsumerState representing the consumer's positions.
      */
-    public ConsumerState seek(final Map<Integer, Long> partitionOffsetMap) {
-        for (final Map.Entry<Integer, Long> entry: partitionOffsetMap.entrySet()) {
-            kafkaConsumer.seek(
-                new TopicPartition(clientConfig.getTopicConfig().getTopicName(), entry.getKey()),
-                entry.getValue()
-            );
-        }
-        commit();
-        return getConsumerState();
-    }
+    ConsumerState seek(final Map<Integer, Long> partitionOffsetMap);
 
     /**
      * Seek consumer to specific timestamp
      * @param timestamp Unix timestamp in milliseconds to seek to.
      */
-    public ConsumerState seek(final long timestamp) {
-        // Find offsets for timestamp
-        final Map<TopicPartition, Long> timestampMap = new HashMap<>();
-        for (final TopicPartition topicPartition: getAllPartitions()) {
-            timestampMap.put(topicPartition, timestamp);
-        }
-        final Map<TopicPartition, OffsetAndTimestamp> offsetMap = kafkaConsumer.offsetsForTimes(timestampMap);
-
-        // Build map of partition => offset
-        final Map<Integer, Long> partitionOffsetMap = new HashMap<>();
-        for (Map.Entry<TopicPartition, OffsetAndTimestamp> entry: offsetMap.entrySet()) {
-            partitionOffsetMap.put(entry.getKey().partition(), entry.getValue().offset());
-        }
-
-        // Now lets seek to those offsets
-        return seek(partitionOffsetMap);
-    }
-
-    private List<PartitionOffset> getHeadOffsets() {
-        final Map<TopicPartition, Long> results = kafkaConsumer.beginningOffsets(getAllPartitions());
-
-        final List<PartitionOffset> offsets = new ArrayList<>();
-        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
-            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
-        }
-        return offsets;
-    }
-
-    private List<PartitionOffset> getTailOffsets() {
-        final Map<TopicPartition, Long> results = kafkaConsumer.endOffsets(getAllPartitions());
-
-        final List<PartitionOffset> offsets = new ArrayList<>();
-        for (final Map.Entry<TopicPartition, Long> entry : results.entrySet()) {
-            offsets.add(new PartitionOffset(entry.getKey().partition(), entry.getValue()));
-        }
-        return offsets;
-    }
-
-    private ConsumerState getConsumerState() {
-        final List<PartitionOffset> offsets = new ArrayList<>();
-
-        for (final TopicPartition topicPartition: getAllPartitions()) {
-            final long offset = kafkaConsumer.position(topicPartition);
-            offsets.add(new PartitionOffset(topicPartition.partition(), offset));
-        }
-
-        return new ConsumerState(clientConfig.getTopicConfig().getTopicName(), offsets);
-    }
-
-    private List<TopicPartition> getAllPartitions() {
-        // If we have not pulled this yet
-        if (cachedTopicsAndPartitions == null) {
-            // Determine which partitions to subscribe to, for now do all
-            final List<PartitionInfo> partitionInfos = kafkaConsumer.partitionsFor(clientConfig.getTopicConfig().getTopicName());
-
-            // Pull out partitions, convert to topic partitions
-            cachedTopicsAndPartitions = new ArrayList<>();
-            for (final PartitionInfo partitionInfo : partitionInfos) {
-                // Skip filtered partitions
-                if (!clientConfig.isPartitionFiltered(partitionInfo.partition())) {
-                    cachedTopicsAndPartitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
-                }
-            }
-        }
-        return cachedTopicsAndPartitions;
-    }
-
-    private void commit() {
-        kafkaConsumer.commitSync();
-    }
+    ConsumerState seek(final long timestamp);
 
     /**
      * Closes out the consumer.
      */
-    public void close() {
-        kafkaConsumer.close();
-    }
+    void close();
 
     /**
      * Seek to the previous 'page' of records.
      */
-    public void previous() {
-        // Get all available partitions
-        final List<TopicPartition> topicPartitions = getAllPartitions();
-
-        // Get head offsets for each partition
-        final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
-
-        // Loop over each partition
-        for (final TopicPartition topicPartition: topicPartitions) {
-            // Calculate our previous offsets
-            final long headOffset = headOffsets.get(topicPartition);
-            final long currentOffset = kafkaConsumer.position(topicPartition);
-            long newOffset = currentOffset - (clientConfig.getMaxResultsPerPartition() * 2);
-
-            // Can't go before the head position!
-            if (newOffset < headOffset) {
-                newOffset = headOffset;
-            }
-
-            logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
-
-            // Seek to earlier offset
-            kafkaConsumer.seek(topicPartition, newOffset);
-        }
-        commit();
-    }
+    void previous();
 
     /**
      * Seek to the next 'page' of records.
      */
-    public void next() {
-        // Get all available partitions
-        final List<TopicPartition> topicPartitions = getAllPartitions();
-
-        // Get head offsets for each partition
-        final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
-
-        // Loop over each partition
-        for (final TopicPartition topicPartition: topicPartitions) {
-            // Calculate our previous offsets
-            final long tailOffset = tailOffsets.get(topicPartition);
-            final long currentOffset = kafkaConsumer.position(topicPartition);
-            long newOffset = currentOffset + clientConfig.getMaxResultsPerPartition();
-
-            if (newOffset < tailOffset) {
-                newOffset = tailOffset;
-            }
-            logger.info("Partition: {} Previous Offset: {} New Offset: {}", topicPartition.partition(), currentOffset, newOffset);
-
-            // Seek to earlier offset
-            kafkaConsumer.seek(topicPartition, newOffset);
-        }
-        commit();
-    }
+    void next();
 
     /**
      * Seek to the HEAD of a topic.
      */
-    public ConsumerState toHead() {
-        // Get all available partitions
-        final List<TopicPartition> topicPartitions = getAllPartitions();
-
-        // Get head offsets for each partition
-        final Map<TopicPartition, Long> headOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
-
-        // Loop over each partition
-        for (final TopicPartition topicPartition: topicPartitions) {
-            final long newOffset = headOffsets.get(topicPartition);
-            logger.info("Resetting Partition: {} To Head Offset: {}", topicPartition.partition(), newOffset);
-
-            // Seek to earlier offset
-            kafkaConsumer.seek(topicPartition, newOffset);
-        }
-        commit();
-
-        return getConsumerState();
-    }
+    ConsumerState toHead();
 
     /**
      * Seek to the TAIL of a topic.
      */
-    public ConsumerState toTail() {
-        // Get all available partitions
-        final List<TopicPartition> topicPartitions = getAllPartitions();
-
-        // Get head offsets for each partition
-        final Map<TopicPartition, Long> tailOffsets = kafkaConsumer.endOffsets(topicPartitions);
-
-        // Loop over each partition
-        for (final TopicPartition topicPartition: topicPartitions) {
-            final long newOffset = tailOffsets.get(topicPartition);
-            logger.info("Resetting Partition: {} To Tail Offset: {}", topicPartition.partition(), newOffset);
-
-            // Seek to earlier offset
-            kafkaConsumer.seek(topicPartition, newOffset);
-        }
-        commit();
-
-        return getConsumerState();
-    }
+    ConsumerState toTail();
 }

--- a/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactory.java
+++ b/kafka-webview-ui/src/main/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerFactory.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Factory class for creating new Kafka Consumers to be used by WebRequests.
@@ -70,6 +71,9 @@ public class WebKafkaConsumerFactory {
     private final SecretManager secretManager;
     private final KafkaConsumerFactory kafkaConsumerFactory;
 
+    //  Multi-threaded consumer
+    private final ExecutorService multiThreadedConsumerThreadPool;
+
     // For parsing json options
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -80,11 +84,13 @@ public class WebKafkaConsumerFactory {
         final PluginFactory<Deserializer> deserializerPluginFactory,
         final PluginFactory<RecordFilter> recordFilterPluginFactory,
         final SecretManager secretManager,
-        final KafkaConsumerFactory kafkaConsumerFactory) {
+        final KafkaConsumerFactory kafkaConsumerFactory,
+        final ExecutorService multiThreadedConsumerThreadPool) {
         this.deserializerPluginFactory = deserializerPluginFactory;
         this.recordFilterPluginFactory = recordFilterPluginFactory;
         this.secretManager = secretManager;
         this.kafkaConsumerFactory = kafkaConsumerFactory;
+        this.multiThreadedConsumerThreadPool = multiThreadedConsumerThreadPool;
     }
 
     /**
@@ -105,11 +111,15 @@ public class WebKafkaConsumerFactory {
             .withStartingPosition(StartingPosition.newResumeFromExistingState())
             .build();
 
-        // Create kafka consumer
-        final KafkaConsumer kafkaConsumer = createKafkaConsumer(clientConfig);
-
-        // Create consumer
-        return new WebKafkaConsumer(kafkaConsumer, clientConfig);
+        // If we've been passed an executor service
+        if (multiThreadedConsumerThreadPool != null) {
+            // Assume we want to use multi-threaded consumer.
+            return new ParallelWebKafkaConsumer(kafkaConsumerFactory, clientConfig, multiThreadedConsumerThreadPool);
+        } else {
+            // Create single threaded kafka consumer
+            final KafkaConsumer kafkaConsumer = createKafkaConsumer(clientConfig);
+            return new DefaultWebKafkaConsumer(kafkaConsumer, clientConfig);
+        }
     }
 
     /**

--- a/kafka-webview-ui/src/main/resources/config/base.yml
+++ b/kafka-webview-ui/src/main/resources/config/base.yml
@@ -48,6 +48,8 @@ app:
   name: Kafka Web View
   uploadPath: "./data/uploads"
   key: "SuperSecretKey"
+  multiThreadedConsumer: false
+  maxConcurrentWebConsumers: 32
   maxConcurrentWebSocketConsumers: 64
   consumerIdPrefix: "KafkaWebViewConsumer"
   requireSsl: true

--- a/kafka-webview-ui/src/main/resources/config/base.yml
+++ b/kafka-webview-ui/src/main/resources/config/base.yml
@@ -48,7 +48,7 @@ app:
   name: Kafka Web View
   uploadPath: "./data/uploads"
   key: "SuperSecretKey"
-  multiThreadedConsumer: false
+  multiThreadedConsumer: true
   maxConcurrentWebConsumers: 32
   maxConcurrentWebSocketConsumers: 64
   consumerIdPrefix: "KafkaWebViewConsumer"

--- a/kafka-webview-ui/src/main/resources/config/dev.yml
+++ b/kafka-webview-ui/src/main/resources/config/dev.yml
@@ -16,7 +16,6 @@ spring:
 
 app:
   requireSsl: false
-  multiThreadedConsumer: true
   user:
     enabled: true
     ## Development server Ldap auth settings

--- a/kafka-webview-ui/src/main/resources/config/dev.yml
+++ b/kafka-webview-ui/src/main/resources/config/dev.yml
@@ -16,6 +16,7 @@ spring:
 
 app:
   requireSsl: false
+  multiThreadedConsumer: true
   user:
     enabled: true
     ## Development server Ldap auth settings

--- a/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerTest.java
+++ b/kafka-webview-ui/src/test/java/org/sourcelab/kafka/webview/ui/manager/kafka/WebKafkaConsumerTest.java
@@ -84,7 +84,7 @@ public class WebKafkaConsumerTest {
         final KafkaConsumer kafkaConsumer = kafkaConsumerFactory.createConsumerAndSubscribe(clientConfig);
 
         // Create consumer
-        final WebKafkaConsumer webKafkaConsumer = new WebKafkaConsumer(kafkaConsumer, clientConfig);
+        final WebKafkaConsumer webKafkaConsumer = new DefaultWebKafkaConsumer(kafkaConsumer, clientConfig);
 
         // Poll
         final KafkaResults results = webKafkaConsumer.consumePerPartition();

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.sourcelab</groupId>
     <artifactId>kafka-webview</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 
     <!-- Define submodules -->
     <modules>


### PR DESCRIPTION
This should help speed up consuming considerably against topics with a large number of partitions, or higher latency network links.

This *may* help with #132 but not confirmed.