### PR TITLE
Fixed shebang, so that 'if [[ ... ]]'  works.

### DIFF
--- a/kafka-webview-ui/src/assembly/distribution/start.sh
+++ b/kafka-webview-ui/src/assembly/distribution/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CWD=`pwd`
 


### PR DESCRIPTION
The script uses `bash` syntax but the shebang was `sh`. So execution only works with `bash start.sh` and not wiht `./start.sh` or `/some/path/start.sh`